### PR TITLE
docs(bg): add raid prerequisite, dual-worker architecture, and technical review notes

### DIFF
--- a/docs_temp/battleground chatters/battleground-chatter-vision.md
+++ b/docs_temp/battleground chatters/battleground-chatter-vision.md
@@ -276,6 +276,49 @@ These are specifically designed for the RP audience — the kind of messages tha
 
 ---
 
+## Dual-Worker Delivery Model (Added Review Session)
+
+BG chatter is delivered through two separate processing layers, each serving a different purpose:
+
+### Raid Worker — "The Crowd"
+
+This worker creates the feeling of being in a large, living team. It reacts to major BG events by picking random bots from **across the entire raid** (outside the player's sub-group) to speak.
+
+- **Events**: match start, match end, flag captures, node captures, boss kills, wipes, epic loot
+- **Channel**: `CHAT_MSG_RAID` (visible to full team) or `CHAT_MSG_BATTLEGROUND` (0x2C)
+- **Frequency**: Low — these are rare, high-impact moments
+- **Bot selection**: Random bots from other sub-groups, so the player hears "the crowd" reacting
+- **Personality**: Lightweight — race/class identity is enough, no full trait generation
+- **Tone**: Epic, faction-proud, urgent callouts
+
+Example: A boss dies in AV. A Dwarf warrior from sub-group 3 shouts in raid chat: "The beast is down! Push forward, lads!"
+
+### Group Worker — "The Squad"
+
+This is the existing group chatter system, scoped to the player's sub-group. It handles both normal group events AND reacts to raid/BG events with a more personal, intimate tone.
+
+- **Events**: kills, deaths, loot, spells, player chat responses, AND the same big events the raid worker handles (but with personal flavor)
+- **Channel**: `CHAT_MSG_PARTY` via `SayToParty()` (reaches sub-group only)
+- **Frequency**: Normal group chatter rates, dynamically scaled by sub-group size (not raid size)
+- **Bot selection**: Only bots in the player's sub-group
+- **Personality**: Full trait system — the same bots the player has been playing with all session
+- **Tone**: Personal, familiar, squad-level banter
+
+Example: Same boss dies. The Priest in the player's sub-group says in party chat: "That was close. Thought we were going to wipe for a second there."
+
+### The Combined Effect
+
+The same event can produce **two complementary reactions**: someone across the raid shouting in raid chat, and a bot next to you in party chat making a personal comment. This is exactly how real raids and BGs feel — the crowd cheers while your friend leans over and says something just to you.
+
+**Coordination rules:**
+- A bot picked by the raid worker for an event must NOT also react via the group worker for the same event
+- Separate cooldowns per worker, with a shared "big event" cooldown to prevent message floods
+- The raid worker stays subtle — 1-2 messages per major event, never more
+
+This model applies to both normal PvE raids AND battlegrounds. In BGs, the raid worker additionally handles BG-specific events (flag state changes, node contests, score milestones) while the group worker handles combat events (PvP kills, deaths, heals) scoped to the sub-group.
+
+---
+
 ## What We DO NOT Want
 
 The core rule is simple: **no overworld event types should fire during a battleground.** If the only events reaching the LLM are BG events, and the LLM knows it's in a battleground, it will naturally produce the right tone. We don't need to over-constrain its creativity — just make sure the wrong triggers never fire.
@@ -284,7 +327,7 @@ The core rule is simple: **no overworld event types should fire during a battleg
 
 These mod-llm-chatter events must be completely suppressed when a player is in a battleground. They are disconnected from the BG context and would break immersion:
 
-- **Loot reactions** — no item drop excitement mid-battle
+- **Loot reactions** — no item drop excitement mid-battle (exception: AV turn-in items like Armor Scraps, Storm Crystals, Frostwolf Medallions are BG objectives and could warrant reactions)
 - **Quest objective/completion messages** — irrelevant in BG context
 - **Trade / crafting references** — not the time or place
 - **Holiday / seasonal event messages** — "Happy Brewfest!" during a flag fight is absurd

--- a/docs_temp/battleground chatters/battleground-investigation.md
+++ b/docs_temp/battleground chatters/battleground-investigation.md
@@ -26,15 +26,34 @@ Group chatter events like loot reactions, quest objectives, and level-ups would 
 
 ### AllBattlegroundScript Hooks (ScriptMgr)
 
-These are global hooks that fire for ALL battlegrounds. We can register our own `AllBattlegroundScript` subclass.
+These are global hooks that fire for ALL battlegrounds. We can register our own `AllBattlegroundScript` subclass (alias: `BGScript`).
 
-| Hook | When It Fires | Chatter Use |
-|------|--------------|-------------|
-| `OnBattlegroundStart(bg)` | Match begins | "Let's do this!" battle cry |
-| `OnBattlegroundEnd(bg, winnerTeamId)` | Match ends | Victory/defeat reaction |
-| `OnBattlegroundAddPlayer(bg, player)` | Player joins BG instance | Arrival comment (replaces group join) |
-| `OnBattlegroundRemovePlayerAtLeave(bg, player)` | Player leaves BG | Farewell/ragequit comment |
-| `OnBattlegroundUpdate(bg, diff)` | Every world tick | Periodic state checks (score changes, flag state) |
+| Hook | Signature | When It Fires | Chatter Use |
+|------|-----------|--------------|-------------|
+| `OnBattlegroundCreate` | `(Battleground* bg)` | BG instance created | Internal: initialize state tracking |
+| `OnBattlegroundDestroy` | `(Battleground* bg)` | BG instance cleaned up | Internal: clean up state maps |
+| `OnBattlegroundBeforeAddPlayer` | `(Battleground* bg, Player* player)` | Start of `AddPlayer()`, before group assignment | Early detection |
+| `OnBattlegroundAddPlayer` | `(Battleground* bg, Player* player)` | End of `AddPlayer()`, after group assignment | Arrival comment |
+| `OnBattlegroundStart` | `(Battleground* bg)` | BG transitions to `STATUS_IN_PROGRESS` | "Let's do this!" battle cry |
+| `OnBattlegroundEnd` | `(Battleground* bg, TeamId winnerTeamId)` | End of `EndBattleground()` | Victory/defeat reaction |
+| `OnBattlegroundEndReward` | `(Battleground* bg, Player* player, TeamId winnerTeamId)` | Per-player during reward loop | Individual win/loss reaction |
+| `OnBattlegroundUpdate` | `(Battleground* bg, uint32 diff)` | Every BG tick, end of `Battleground::Update()` | State polling (scores, flags, nodes) |
+| `OnBattlegroundRemovePlayerAtLeave` | `(Battleground* bg, Player* player)` | End of `RemovePlayerAtLeave()` | Farewell/ragequit comment |
+
+**Additional hooks (queue/matchmaking — less relevant for chatter):**
+`OnQueueUpdate`, `OnAddGroup`, `CanFillPlayersToBG`, `IsCheckNormalMatch`, `CanSendMessageBGQueue`, `OnBeforeSendJoinMessageArenaQueue`, `OnBeforeSendExitMessageArenaQueue`
+
+### PlayerScript BG-Specific Hooks
+
+These PlayerScript hooks fire specifically for BG/arena transitions — separate from the general PlayerScript hooks:
+
+| Hook | Signature | When It Fires |
+|------|-----------|--------------|
+| `OnPlayerAddToBattleground` | `(Player* player, Battleground* bg)` | Player added to BG |
+| `OnPlayerRemoveFromBattleground` | `(Player* player, Battleground* bg)` | Player removed from BG |
+| `OnPlayerJoinBG` | `(Player* player)` | Player joins a BG |
+| `OnPlayerJoinArena` | `(Player* player)` | Player joins an arena |
+| `OnPlayerBattlegroundDesertion` | `(Player* player, BattlegroundDesertionType type)` | Player deserts a BG |
 
 ### PlayerScript Hooks That Fire in BGs
 
@@ -103,15 +122,35 @@ player->InBattleground()                    // bool
 player->GetBattleground()                   // Battleground* (or nullptr)
 player->GetBattlegroundTypeId()             // BattlegroundTypeId enum
 
-// BG type identification
-enum BattlegroundTypeId : uint8 {
-    BATTLEGROUND_WS = 1,   // Warsong Gulch (10v10, CTF)
-    BATTLEGROUND_AB = 2,   // Arathi Basin (15v15, nodes)
-    BATTLEGROUND_AV = 3,   // Alterac Valley (40v40, PvE+PvP)
-    BATTLEGROUND_EY = 4,   // Eye of the Storm (15v15, flag+nodes)
-    BATTLEGROUND_SA = 5,   // Strand of the Ancients (15v15, siege)
-    BATTLEGROUND_IC = 6,   // Isle of Conquest (40v40, vehicles)
+// BG type identification (from DBCEnums.h)
+enum BattlegroundTypeId {
+    BATTLEGROUND_AV  = 1,   // Alterac Valley (40v40, PvE+PvP)
+    BATTLEGROUND_WS  = 2,   // Warsong Gulch (10v10, CTF)
+    BATTLEGROUND_AB  = 3,   // Arathi Basin (15v15, nodes)
+    BATTLEGROUND_NA  = 4,   // Nagrand Arena
+    BATTLEGROUND_BE  = 5,   // Blade's Edge Arena
+    BATTLEGROUND_AA  = 6,   // All Arenas
+    BATTLEGROUND_EY  = 7,   // Eye of the Storm (15v15, flag+nodes)
+    BATTLEGROUND_RL  = 8,   // Ruins of Lordaeron Arena
+    BATTLEGROUND_SA  = 9,   // Strand of the Ancients (15v15, siege)
+    BATTLEGROUND_DS  = 10,  // Dalaran Sewers Arena
+    BATTLEGROUND_RV  = 11,  // Ring of Valor Arena
+    BATTLEGROUND_IC  = 30,  // Isle of Conquest (40v40, vehicles)
+    BATTLEGROUND_RB  = 32,  // Random Battleground
 };
+
+// Map-level detection (Map.h) — delegates to MapEntry DBC data
+map->Instanceable()            // true for Dungeons, Raids, BGs, Arenas
+map->IsDungeon()               // true for Dungeons AND Raids
+map->IsNonRaidDungeon()        // true for 5-man dungeons only
+map->IsRaid()                  // true for raids only (10/25-man)
+map->IsBattleground()          // true for BGs only (AV, WSG, AB, EY, SA, IC)
+map->IsBattleArena()           // true for arenas only
+map->IsBattlegroundOrArena()   // true for both BGs and arenas
+
+// NOTE: The ambient General channel chatter already checks !map->Instanceable()
+// which correctly blocks it in BGs. Group chatter does NOT have this check
+// and will fire in BGs — this is the desired behavior for the group worker.
 
 // Team in BG
 player->GetBgTeamId()                       // TEAM_ALLIANCE or TEAM_HORDE
@@ -162,6 +201,106 @@ ey->GetFlagPickerGUID()                      // Central flag carrier
 ey->GetCapturePointInfo(point)._ownerTeamId  // Base ownership
 // 4 bases + 1 central flag, first to 1600 wins
 ```
+
+---
+
+## Prerequisite: Raid Awareness (Before BG Work)
+
+BGs use raid groups (`GROUPTYPE_BGRAID = 0x03`). The existing group chatter system assumes small parties (2-5 players). Before implementing BG-specific features, raid-aware group chatter must work correctly. This is a natural stepping stone because:
+
+- The same GroupScript hooks (`OnAddMember`, `OnRemoveMember`, `OnDisband`) fire identically for parties, raids, and BG raids — there are no separate raid-specific hooks
+- All PlayerScript hooks (`OnPlayerCreatureKill`, `OnPlayerLootItem`, spell casts, etc.) fire regardless of group type
+- `SayToParty()` already works in raids — it sends `CHAT_MSG_PARTY` which reaches the sub-group (the 5-person party within the raid), and the real player is in the same sub-group as their bots
+- The existing group chatter is essentially **plug-and-play in raids** — it just needs volume tuning
+
+### Raid Group Type Detection
+
+```cpp
+// Group type flags (GroupType enum)
+GROUPTYPE_NORMAL  = 0x00  // Normal party (2-5)
+GROUPTYPE_BG      = 0x01  // BG flag
+GROUPTYPE_RAID    = 0x02  // Raid flag
+GROUPTYPE_BGRAID  = 0x03  // BG + Raid (all BG groups)
+
+// Detection methods
+group->isRaidGroup()  // true for raids AND BG raids (checks GROUPTYPE_RAID flag)
+group->isBGGroup()    // true ONLY for BG groups (checks m_bgGroup != nullptr)
+group->isBFGroup()    // true ONLY for Battlefield groups (Wintergrasp)
+
+// Clean distinction:
+// Normal raid (dungeon/raid instance): isRaidGroup()=true, isBGGroup()=false
+// BG raid: isRaidGroup()=true, isBGGroup()=true
+```
+
+### What Needs Tuning for Raids
+
+The philosophy: **sub-group = the social unit, raid-wide = epic moments only**. Most chatter stays intimate within the player's sub-group. Rare, impactful events (boss kills, wipes) get raid-wide reactions that make the player feel the scale.
+
+**Scoping to sub-groups:**
+```cpp
+uint8 playerSubGroup = player->GetSubGroup();
+// Only pick bots from the same sub-group for reactions
+// SayToParty() already delivers to sub-group only — this is correct
+```
+
+**Events that should work at sub-group level (existing logic, just scoped):**
+- Greetings (throttled — pick 1-2 bots from sub-group, not all raid members)
+- Kill/death reactions
+- Loot reactions
+- Spell cast reactions
+- Player chat responses
+
+**Events that should be disabled in raids:**
+- Idle chatter / ambient banter
+- Group composition commentary
+
+**Events that deserve raid-wide delivery (epic moments):**
+- Boss kills
+- Wipes
+- Legendary/epic loot (raid-wide celebration)
+
+### Dual-Worker Architecture for Raids and BGs
+
+Two separate processing layers react to the same events:
+
+**Raid Worker** — the "crowd"
+- Listens to raid-scope events: boss kills, wipes, phase transitions, epic loot
+- Picks random bots from **across the whole raid** (outside the player's sub-group) to speak
+- Delivers via raid chat (`CHAT_MSG_RAID`) — requires building the packet manually since `SayToRaid()` is broken
+- Low frequency, high impact — makes the player feel surrounded by a living raid
+- Lightweight bot identity — race/class is enough for personality, no full trait generation needed
+
+**Group Worker** — the "squad" (existing system, sub-group scoped)
+- All current group chatter logic: greetings, kills, loot, spells, player responses
+- Also reacts to raid events — so a boss kill triggers both a raid-wide callout AND a sub-group personal comment
+- Scoped to the player's sub-group only
+- Delivers via `SayToParty()` as today
+- Higher frequency, intimate feel
+
+**Coordination between workers:**
+- The bot picked by the raid worker for a given event must NOT also be the one reacting in the group worker
+- Separate cooldowns per worker, but a shared "big event" cooldown to prevent 5+ simultaneous messages from one event
+- Both workers can access mood drift data — a bot who's been dying all raid sounds frustrated regardless of which worker picks them
+
+This dual-worker model applies to both normal raids AND battlegrounds. In BGs, the raid worker handles BG-specific events (flag captures, match start/end) while the group worker handles combat events (kills, deaths, spells) scoped to the sub-group.
+
+### SayToRaid Packet Construction
+
+Since `PlayerbotAI::SayToRaid()` has an inverted condition bug and cannot be relied on, the raid worker must build `CHAT_MSG_RAID` packets directly:
+
+```cpp
+// Same pattern as SayToParty but with CHAT_MSG_RAID
+WorldPacket data;
+ChatHandler::BuildChatPacket(data, CHAT_MSG_RAID, msg.c_str(),
+    LANG_UNIVERSAL, CHAT_TAG_NONE, bot->GetGUID(), bot->GetName());
+// Send to each real player in the group via GetRealPlayersInGroup()
+```
+
+For BG-specific team chat, use `CHAT_MSG_BATTLEGROUND` (0x2C) instead of `CHAT_MSG_RAID`.
+
+### Performance Note: GetRealPlayersInGroup()
+
+`PlayerbotAI::GetRealPlayersInGroup()` iterates ALL group members on every call. In a 40-player AV this means 40 iterations per message delivery. For the raid worker, consider caching the real player list per tick or using an early-exit pattern since most raids have only 1 real player.
 
 ---
 
@@ -297,6 +436,98 @@ In BGs, the raid is split into sub-groups. The real player's bots are typically 
 
 ### Arena Exclusion
 Arenas (2v2, 3v3, 5v5) are also "battlegrounds" technically (`bg->isArena()` returns true). Chatter should probably be disabled in arenas — they're short, intense, and chat would be distracting. Always check `bg->isBattleground()` (true for BGs, false for arenas) rather than `player->InBattleground()` (true for both).
+
+### BG Queue/Join Transition Flow
+
+When a player accepts a BG queue pop, this sequence occurs:
+
+1. **Bots do NOT follow masters into BGs** — they queue independently via playerbots `BGJoinAction` and accept via `CMSG_BATTLEFIELD_PORT`. There is no automatic "follow master" mechanic for BGs.
+2. **Original world group is preserved** — `player->GetOriginalGroup()` stores the pre-BG group. It's restored on BG exit.
+3. **A new BG raid group is created** per team via `AddOrSetPlayerToCorrectBgGroup()`. This calls `group->AddMember(player)` which fires `OnAddMember` GroupScript hooks — this is the source of greeting spam.
+4. **On BG exit**, the player returns to their original world group automatically.
+
+**Transition concerns:**
+- The `OnRemoveMember` hook does NOT fire during BG entry for the original group — the group is preserved, not disbanded
+- However, if bots are removed from the world group for other reasons during BG, farewell messages could fire incorrectly — suppress farewells when `player->InBattleground()` or `player->InBattlegroundQueue()`
+- `OnAddMember` fires for each bot joining the BG raid — this is where greeting suppression must happen for BG groups (check `group->isBGGroup()`)
+
+### BG Battleground Status Enum
+
+```cpp
+enum BattlegroundStatus
+{
+    STATUS_NONE       = 0,  // not instanced
+    STATUS_WAIT_QUEUE = 1,  // empty, waiting for queue
+    STATUS_WAIT_JOIN  = 2,  // players entering, countdown (pre-gate phase)
+    STATUS_IN_PROGRESS = 3, // running
+    STATUS_WAIT_LEAVE = 4   // winner declared, ending
+};
+```
+
+### TeamId vs PvPTeamId Gotcha
+
+```cpp
+// IMPORTANT: These have OPPOSITE ordinals for Alliance/Horde
+enum TeamId    { TEAM_ALLIANCE = 0, TEAM_HORDE = 1, TEAM_NEUTRAL = 2 };
+enum PvPTeamId { PVP_TEAM_HORDE = 0, PVP_TEAM_ALLIANCE = 1, PVP_TEAM_NEUTRAL = 2 };
+
+// EndBattleground() takes PvPTeamId internally, but the OnBattlegroundEnd hook
+// receives TeamId (converted via GetTeamId()). Always use the hook parameter directly.
+```
+
+### Anti-Repetition: Instance ID vs Zone ID
+
+The existing anti-repetition system uses `zone_id` for cooldown keys. Multiple concurrent BG instances share the same zone ID (all WSG instances are zone 3277). This means a cooldown triggered in one WSG instance would incorrectly suppress messages in a different WSG instance. **Extend the cooldown key to include `bg->GetInstanceID()`** for BG events.
+
+### AV Turn-In Items Exception
+
+Loot reactions are suppressed in BGs, but Alterac Valley has collectible turn-in items (Armor Scraps, Storm Crystals, Frostwolf Medallions, etc.) that are core BG objectives. Consider a BG-specific loot allowlist for AV rather than blanket suppression.
+
+### Flag Carrier Death Optimization
+
+In addition to polling `GetFlagState()` in `OnBattlegroundUpdate`, the `OnPlayerPVPKill` hook can provide instant flag-drop detection by comparing the victim's GUID against `GetFlagPickerGUID()`. This gives a more precise and immediate reaction: "Dropped their carrier!" rather than the generic "Flag's down!" from state polling.
+
+### SotA Round Swap Detection
+
+Strand of the Ancients has two rounds where teams swap attacker/defender roles. The `OnBattlegroundUpdate` polling needs to detect this phase transition and pass the current role (attacking/defending) to the LLM — the tone is completely different between offense and defense. Track `bg->GetStatus()` transitions and team role assignments.
+
+### IoC Vehicle Context
+
+Isle of Conquest has siege engines, demolishers, glaive throwers, and catapults. `player->GetVehicle()` can detect if a bot is in a vehicle. Not critical for initial implementation but would add depth for IoC-specific reactions.
+
+### Dynamic Scaling in Raids/BGs
+
+The existing dynamic trigger scaling (chance divided by number of bots in group) already reduces reaction chances as group size grows. This same logic must apply at the **sub-group level** for the group worker in raids, not the full raid size. The goal: **message volume should stay constant regardless of how many bots are in the raid**. A player in a 5-bot party and a player in a 40-bot raid should experience roughly the same frequency of sub-group chatter.
+
+For the group worker:
+- Scale chances by sub-group bot count (typically 4), not total raid bot count
+- Idle chatter disabled entirely in raids — no scaling needed
+
+For the raid worker:
+- Scale by total raid size to stay subtle at any scale
+- A 10-man and a 40-man raid should produce similar raid-wide message rates
+- Low base frequency (much lower than group worker) ensures it stays background atmosphere
+
+### Emote Delivery for Raid/BG Channels
+
+The current emote system only delivers emotes for `channel=="party"`. For the raid worker's messages delivered via `CHAT_MSG_RAID` or `CHAT_MSG_BATTLEGROUND`, the emote delivery guard in C++ needs to be extended to also allow emotes for these channels. Without this, emotes like `/charge` at gates opening or `/cheer` on boss kills would silently be dropped.
+
+### Pre-Cache Candidates for BG
+
+The highest-value pre-cache categories for BGs are:
+- **Match start** — gates open, multiple bots need battle cries simultaneously. Zero-latency critical.
+- **PvP kills** — happen fast and frequently. Pre-cached "Got one!" / "Nice kill!" feels much more responsive than 3-8s LLM latency.
+- **Flag captures** — team-wide celebration moments, should feel instant.
+
+These are predictable events with templatable responses — ideal pre-cache candidates.
+
+### Mood Initialization for BG
+
+The mood system initializes at neutral and drifts based on events. In BGs, bots join fresh with no mood history. Consider personality-based initialization: a warrior starts "fired up", a priest starts "cautious". The pre-gate waiting room phase is the natural window for this.
+
+### Consecutive BG Memory
+
+The "Consecutive Match Memory" feature (Gaps and Enrichments section) should track per-bot-GUID, not just per-player-GUID. Each bot should remember their own BG experience ("I died 8 times last match" vs "I went on a killing spree") for more immersive cross-match references.
 
 ---
 

--- a/docs_temp/gameobject-awareness-investigation.md
+++ b/docs_temp/gameobject-awareness-investigation.md
@@ -1,0 +1,490 @@
+# GameObject Awareness Chatter — Feasibility Investigation
+
+As you walk through zones, dungeons, and cities with your group, a bot is occasionally picked at random. Nearby GameObjects within ~20 meters are detected around that bot, and the object data is fed to the LLM, which crafts a creative, in-character comment about what the bot notices. The message is assigned to that bot and displayed in party chat.
+
+A Dwarf warrior passing a forge might say: "Now that's a proper anvil. Reminds me of the Great Forge back home."
+A Night Elf druid near a moonwell: "I can feel Elune's presence here. The waters still hold her blessing."
+A Warlock glancing at a skull pile: "Lovely décor. I should take notes."
+
+---
+
+## Verdict: Highly Feasible
+
+AzerothCore and playerbots both have mature, battle-tested APIs for finding and inspecting nearby GameObjects. The grid search is efficient, the data model is rich, and playerbots already uses these exact patterns for loot detection, RPG behavior, and trap avoidance. No engine modifications needed — everything can be done from our module's C++ hooks.
+
+---
+
+## Core APIs
+
+### Finding Nearby GameObjects
+
+All methods live on `WorldObject` (which `Player` inherits from). Since bot players are `Player*`, we call these directly.
+
+**Option A: All GOs in radius (what we want)**
+
+The playerbots-proven pattern using `Cell::VisitObjects`:
+
+```cpp
+#include "CellImpl.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+
+std::list<GameObject*> targets;
+AnyGameObjectInObjectRangeCheck check(bot, radius);
+Acore::GameObjectListSearcher<AnyGameObjectInObjectRangeCheck> searcher(bot, targets, check);
+Cell::VisitObjects(bot, searcher, radius);
+// targets now contains all spawned GOs with valid GOInfo within radius
+```
+
+The `AnyGameObjectInObjectRangeCheck` filter (from playerbots `NearestGameObjects.h`) accepts any GO that is:
+- Within distance (`IsWithinDistInMap`)
+- Spawned (`isSpawned()`)
+- Has valid template data (`GetGOInfo()`)
+
+**Option B: Convenience methods (for specific lookups)**
+
+```cpp
+// Find nearest single GO by type
+GameObject* forge = bot->FindNearestGameObjectOfType(GAMEOBJECT_TYPE_SPELL_FOCUS, 22.0f);
+
+// Find nearest single GO by entry ID
+GameObject* go = bot->FindNearestGameObject(entryId, 22.0f);
+
+// Find all GOs of specific entry in range
+std::list<GameObject*> list;
+bot->GetGameObjectListWithEntryInGrid(list, entryId, 22.0f);
+```
+
+**For our feature, Option A is the right choice** — we want to discover ALL interesting GOs nearby, not search for specific entries.
+
+### Distance Units
+
+WoW uses **yards** internally. 1 yard ≈ 0.9144 meters.
+
+- 20 real meters ≈ **22 yards** — this is our target scan radius
+- For reference: `INTERACTION_DISTANCE` is ~5 yards, playerbots `lootDistance` is 15 yards, `sightDistance` is 100 yards
+
+22 yards is a small search radius that will typically touch only 1-4 grid cells. Very cheap.
+
+---
+
+## Data Available on Each GameObject
+
+Once we have a `GameObject*`, we can extract:
+
+### Identity
+
+```cpp
+go->GetEntry()                                    // uint32 — template/entry ID
+go->GetGUID()                                     // ObjectGuid — unique instance ID
+go->GetNameForLocaleIdx(sWorld->GetDefaultDbcLocale())  // string — localized display name
+go->GetGOInfo()->name                             // string — English template name
+go->GetDisplayId()                                // uint32 — visual model ID
+```
+
+### Type Classification
+
+```cpp
+go->GetGoType()                                   // GameobjectTypes enum
+go->GetGOInfo()->type                             // Same as above, from template
+go->GetGOInfo()->IconName                         // "Gear", "Point", "", etc.
+```
+
+### State
+
+```cpp
+go->isSpawned()                                   // bool — visible in world
+go->GetGoState()                                  // GO_STATE_ACTIVE, GO_STATE_READY, GO_STATE_ACTIVE_ALTERNATIVE
+go->getLootState()                                // GO_NOT_READY, GO_READY, GO_ACTIVATED, GO_JUST_DEACTIVATED
+go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE)     // Currently being used
+go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED)     // Locked (key/skill needed)
+go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE)  // Invisible/non-interactive
+```
+
+### Template Details
+
+```cpp
+GameObjectTemplate const* info = go->GetGOInfo();
+info->size                                        // float — scale factor
+info->IsForQuests                                 // bool — quest-related
+
+// Type-specific union fields (examples):
+info->spellFocus.focusId                          // SPELL_FOCUS type: forge, anvil, campfire, etc.
+info->chest.lootId                                // Chest: loot table reference
+info->chest.lockId                                // Chest: lock requirement
+info->trap.spellId                                // Trap: what spell it casts
+info->chair.slots                                 // Chair: number of seats
+info->chair.height                                // Chair: seat height
+info->goober.spellId                              // Goober: spell on click
+info->door.lockId                                 // Door: lock requirement
+```
+
+### Spatial
+
+```cpp
+bot->GetDistance(go)                               // float — 3D distance in yards
+bot->GetDistance2d(go)                             // float — 2D (XY) distance
+go->GetPositionX/Y/Z()                            // World coordinates
+bot->IsWithinLOSInMap(go)                         // bool — line of sight check
+```
+
+---
+
+## GameobjectTypes Enum (Full List)
+
+These are the 36 GO types. The **bolded** ones are the most interesting for ambient chatter.
+
+| Value | Type | Examples | Chatter Interest |
+|-------|------|----------|-----------------|
+| 0 | `DOOR` | Instance doors, gates | Low — mostly mechanical |
+| 1 | `BUTTON` | Levers, switches | Low |
+| 2 | `QUESTGIVER` | Quest boards, stones | Medium — "Wonder what's posted here" |
+| **3** | **`CHEST`** | **Treasure chests, herb nodes, mining nodes** | **High — loot/gathering fantasy** |
+| 4 | `BINDER` | Inn binding stones | Low |
+| **5** | **`GENERIC`** | **Statues, banners, decorations, shrines** | **High — lore, atmosphere** |
+| 6 | `TRAP` | Hidden traps | Medium — danger awareness |
+| **7** | **`CHAIR`** | **Chairs, benches, thrones** | **Medium — "Take a seat" moments** |
+| **8** | **`SPELL_FOCUS`** | **Forges, anvils, campfires, cooking fires, moonwells, altars** | **High — class/profession fantasy** |
+| **9** | **`TEXT`** | **Plaques, books, signs, gravestones, monuments** | **High — lore, reading** |
+| **10** | **`GOOBER`** | **Clickable objects: levers, crystals, ritual objects, relics** | **High — mystery, curiosity** |
+| 11 | `TRANSPORT` | Elevators | Low |
+| 12 | `AREADAMAGE` | Area damage zones | Low |
+| 13 | `CAMERA` | Cinematic triggers | None |
+| 14 | `MAP_OBJECT` | Map decorations | None |
+| 15 | `MO_TRANSPORT` | Ships, zeppelins | Medium — travel flavor |
+| 16 | `DUEL_ARBITER` | Duel flags | Low |
+| **17** | **`FISHINGNODE`** | **Fishing bobbers, pools** | **Medium — fishing flavor** |
+| 18 | `SUMMONING_RITUAL` | Summoning stones | Low |
+| **19** | **`MAILBOX`** | **Mailboxes** | **Medium — "Expecting a letter?"** |
+| 20 | `DO_NOT_USE` | — | None |
+| 21 | `GUARDPOST` | Guard spawn points | None — invisible |
+| 22 | `SPELLCASTER` | Teleporters, portals | Medium — travel |
+| **23** | **`MEETINGSTONE`** | **Instance meeting stones** | **Medium — dungeon anticipation** |
+| 24 | `FLAGSTAND` | BG flag stands | BG-specific |
+| **25** | **`FISHINGHOLE`** | **Fishing school spots** | **Medium — fishing flavor** |
+| 26 | `FLAGDROP` | Dropped BG flags | BG-specific |
+| 27 | `MINI_GAME` | Minigames | Low |
+| 28 | `DO_NOT_USE_2` | — | None |
+| 29 | `CAPTURE_POINT` | BG capture points | BG-specific |
+| 30 | `AURA_GENERATOR` | Passive aura sources | None — invisible |
+| 31 | `DUNGEON_DIFFICULTY` | Raid difficulty changers | Low |
+| **32** | **`BARBER_CHAIR`** | **Barber chairs** | **Low — city flavor** |
+| 33 | `DESTRUCTIBLE_BUILDING` | Siege targets | BG/raid specific |
+| 34 | `GUILD_BANK` | Guild bank vaults | Low |
+| 35 | `TRAPDOOR` | Floor traps | Low |
+
+### SpellFocus Sub-Types (Type 8)
+
+`GAMEOBJECT_TYPE_SPELL_FOCUS` is the richest category for chatter. The `spellFocus.focusId` field references `SpellFocusObject.dbc` which identifies what kind of focus it is:
+
+| focusId | Object | Chatter Potential |
+|---------|--------|-------------------|
+| 1 | Anvil | Blacksmithing, crafting |
+| 2 | Loom | Tailoring |
+| 3 | Forge | Metalwork, heat, crafting |
+| 4 | Cooking Fire / Campfire | Warmth, rest, food |
+| 6 | Moonwell | Elune, Night Elf lore |
+| 7 | Altar | Religion, rituals, sacrifices |
+| 8 | Cauldron | Alchemy, potions |
+| 15 | Runeforge | Death Knight |
+
+---
+
+## Filtering: What's Interesting vs What's Noise
+
+Not all GOs are worth commenting on. Many are invisible markers, spell triggers, or mechanical objects.
+
+### Must Filter Out
+
+```cpp
+// Invisible markers — "Point" icon means non-visible game logic object
+if (go->GetGOInfo()->IconName == "Point")
+    continue;
+
+// Non-selectable objects — player can't see or click them
+if (go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE))
+    continue;
+
+// Trap objects — don't reveal hidden traps (immersion breaking)
+if (go->GetGoType() == GAMEOBJECT_TYPE_TRAP)
+    continue;
+
+// BG/arena mechanical objects
+if (go->GetGoType() == GAMEOBJECT_TYPE_FLAGSTAND ||
+    go->GetGoType() == GAMEOBJECT_TYPE_FLAGDROP ||
+    go->GetGoType() == GAMEOBJECT_TYPE_CAPTURE_POINT)
+    continue;
+
+// System objects
+if (go->GetGoType() == GAMEOBJECT_TYPE_DO_NOT_USE ||
+    go->GetGoType() == GAMEOBJECT_TYPE_DO_NOT_USE_2 ||
+    go->GetGoType() == GAMEOBJECT_TYPE_CAMERA ||
+    go->GetGoType() == GAMEOBJECT_TYPE_MAP_OBJECT ||
+    go->GetGoType() == GAMEOBJECT_TYPE_AURA_GENERATOR ||
+    go->GetGoType() == GAMEOBJECT_TYPE_GUARDPOST ||
+    go->GetGoType() == GAMEOBJECT_TYPE_DUEL_ARBITER ||
+    go->GetGoType() == GAMEOBJECT_TYPE_AREADAMAGE ||
+    go->GetGoType() == GAMEOBJECT_TYPE_BINDER)
+    continue;
+```
+
+### High-Interest Types (Prioritize)
+
+```cpp
+static const std::set<GameobjectTypes> highInterestTypes = {
+    GAMEOBJECT_TYPE_SPELL_FOCUS,   // Forges, anvils, campfires, moonwells, altars
+    GAMEOBJECT_TYPE_TEXT,          // Plaques, books, signs, gravestones
+    GAMEOBJECT_TYPE_GENERIC,       // Statues, banners, decorations, shrines
+    GAMEOBJECT_TYPE_GOOBER,        // Clickable objects, crystals, relics
+    GAMEOBJECT_TYPE_CHEST,         // Treasure chests (not lootable by us, just noticed)
+    GAMEOBJECT_TYPE_CHAIR,         // Chairs, benches, thrones
+};
+
+static const std::set<GameobjectTypes> mediumInterestTypes = {
+    GAMEOBJECT_TYPE_QUESTGIVER,    // Quest boards
+    GAMEOBJECT_TYPE_MAILBOX,       // Mailboxes
+    GAMEOBJECT_TYPE_FISHINGNODE,   // Fishing spots
+    GAMEOBJECT_TYPE_FISHINGHOLE,   // Fishing schools
+    GAMEOBJECT_TYPE_MEETINGSTONE,  // Dungeon meeting stones
+    GAMEOBJECT_TYPE_SPELLCASTER,   // Portals, teleporters
+    GAMEOBJECT_TYPE_MO_TRANSPORT,  // Ships, zeppelins
+    GAMEOBJECT_TYPE_DOOR,          // Interesting only in specific contexts (dungeon doors)
+};
+```
+
+### Size Filter
+
+Many tiny decorative GOs have `size < 0.5`. These are typically invisible/ambient clutter. Consider a minimum size threshold, though this needs testing — some interesting objects (books, candles) can be small.
+
+---
+
+## Proposed Architecture
+
+### C++ Side: The Scan Trigger
+
+This runs inside our existing WorldScript or a timer-based approach in `OnWorldUpdate`:
+
+```
+Every N seconds (configurable, e.g., 30-90s):
+  1. For each real player with a bot group:
+     a. Check they're not in combat, not in a BG, not mounted/flying
+     b. Pick a random bot from the group
+     c. Run the GO scan around that bot (22 yard radius)
+     d. Filter results to interesting types
+     e. If interesting GOs found, pick 1-3 of them
+     f. Build JSON payload with GO data
+     g. Insert event into llm_chatter_events table
+```
+
+### Event Data Sent to Python
+
+```json
+{
+    "event_type": "nearby_object",
+    "bot_guid": 12345,
+    "bot_name": "Thaldrin",
+    "bot_class": "Warrior",
+    "bot_race": "Dwarf",
+    "zone_name": "Ironforge",
+    "subzone_name": "The Great Forge",
+    "extra_data": {
+        "objects": [
+            {
+                "name": "Anvil",
+                "type": "SPELL_FOCUS",
+                "type_id": 8,
+                "spell_focus_id": 1,
+                "distance_yards": 8.3,
+                "entry": 1234
+            },
+            {
+                "name": "Forge",
+                "type": "SPELL_FOCUS",
+                "type_id": 8,
+                "spell_focus_id": 3,
+                "distance_yards": 12.1,
+                "entry": 5678
+            }
+        ],
+        "context": "group_travel",
+        "in_city": true,
+        "in_dungeon": false
+    }
+}
+```
+
+### Python Side: Prompt Building
+
+The LLM receives the bot's identity, their nearby objects, and the zone context. It produces a short, in-character observation.
+
+**Prompt pattern:**
+> You are Thaldrin, a Dwarf Warrior. You're walking through The Great Forge in Ironforge with your group. You notice an Anvil nearby and a Forge. Make a brief, in-character observation about what you see. Stay in character — Dwarves love metalwork and forges. One sentence, maybe two. Don't claim any action — just observe or comment.
+
+**Expected output:**
+> "Aye, now that's a proper forge. Could temper a blade to cut through dragon scale on that beauty."
+
+### Delivery
+
+Same pipeline as all other chatter: `llm_chatter_messages` table → `DeliverPendingMessages()` → `SayToParty()`.
+
+---
+
+## Performance Analysis
+
+### Grid Search Cost
+
+`Cell::VisitObjects` with a 22-yard radius:
+- Touches 1-4 grid cells (grids are ~533 yards across, cells within are ~33 yards)
+- Iterates only GOs in those cells, checking phase mask compatibility
+- In a dense city like Ironforge, there might be 20-50 GOs in range
+- In wilderness, typically 0-10
+- Cost: **negligible** — playerbots does this at 100-yard range every second for every bot
+
+### Scan Frequency
+
+If we scan once every 30-90 seconds, and only for one random bot at a time:
+- 1 grid search per 30-90 seconds per real player
+- This is orders of magnitude less than what playerbots already does (every bot, every second, 100yd range)
+- **Zero performance concern**
+
+### LLM Call Cost
+
+One LLM call per scan that finds interesting objects:
+- Many scans will find nothing interesting (especially in wilderness)
+- In cities/towns, maybe 1 call per minute
+- This is well within the existing LLM budget — less frequent than group event reactions
+
+---
+
+## Anti-Repetition
+
+### Per-Object Cooldown
+
+The same GO entry should not trigger chatter twice in a short window. Use a cooldown map:
+
+```
+Key: (bot_guid, go_entry) → last_triggered_timestamp
+Cooldown: 10-15 minutes per object per bot
+```
+
+This prevents a bot from commenting on the same forge every time they pass it.
+
+### Per-Zone Cooldown
+
+In addition to per-object, have a per-zone cooldown for this event type. Walking through Ironforge shouldn't produce 20 forge comments — maybe 1-2 per zone visit.
+
+```
+Key: (player_guid, zone_id) → last_go_chatter_timestamp
+Cooldown: 2-5 minutes per zone
+```
+
+### Object Variety
+
+When multiple interesting GOs are found, prefer objects the bot hasn't commented on recently. Track a rolling window of recently-mentioned GO entries per bot.
+
+### Movement-Based Triggering
+
+Instead of pure timer-based triggering, consider a movement threshold: only scan when the group has moved at least N yards since the last scan. This prevents spam when the group is stationary (resting, AFK) and ensures comments happen during travel — which is the intended use case.
+
+```cpp
+float distanceSinceLastScan = bot->GetDistance2d(lastScanPosition);
+if (distanceSinceLastScan < 50.0f)
+    return;  // Haven't moved enough, skip
+```
+
+---
+
+## Context Awareness
+
+### Where This Feature Should Fire
+
+- **Overworld travel** — walking between quests, exploring zones
+- **Cities and towns** — passing through crafting areas, taverns, monuments
+- **Dungeons** — noticing environmental details, lore objects, decorations
+- **NOT in combat** — suppress when any group member is in combat
+- **NOT in BGs** — BG chatter handles BG environments separately
+- **NOT while mounted/flying** — moving too fast to notice details
+
+### Zone/Subzone Context
+
+The zone and subzone provide critical context for the LLM. "An anvil in Ironforge" evokes very different commentary than "an anvil in a remote Outland camp." Pass both `zone_name` and `subzone_name` to the prompt.
+
+### Class/Profession Affinity
+
+Some GOs are more interesting to specific classes or professions:
+
+| Object | Who Cares Most |
+|--------|---------------|
+| Forge, Anvil | Warriors, Paladins, Death Knights, Blacksmiths |
+| Moonwell | Night Elves, Druids |
+| Altar, Shrine | Priests, Paladins, Warlocks (dark altars) |
+| Herb node | Herbalists, Alchemists |
+| Mining node | Miners, Blacksmiths, Engineers |
+| Campfire | Anyone (rest, warmth), Cooks |
+| Books, Plaques | Mages, Priests, lore-interested personalities |
+| Fishing spots | Anyone with the Fishing skill |
+| Mailbox | Anyone (casual, everyday flavor) |
+
+This affinity could be used for bot selection weighting — when a forge is nearby, prefer to pick the group's warrior or blacksmith for the comment. This creates natural "expertise" moments.
+
+### Dungeon Atmosphere
+
+In dungeons, this feature becomes especially immersive. Dungeon GOs include:
+- Torture devices, skull piles, altars (Scarlet Monastery, Scholomance)
+- Ancient machinery, titan artifacts (Uldaman, Ulduar)
+- Crystals, portals, summoning circles (various)
+- Prison cells, cages, chains (Stockades, BRD)
+- Books and scrolls (Scarlet Monastery library)
+
+These are exactly the kind of environmental details that make a dungeon feel alive when a bot comments on them.
+
+---
+
+## Edge Cases and Gotchas
+
+### Phase Mask
+
+`Cell::VisitObjects` already checks phase compatibility (`InSamePhase`). GOs in a different phase won't appear in results. This is handled automatically.
+
+### Dynamic Spawns
+
+Some GOs spawn/despawn dynamically (gathering nodes, quest objects, seasonal decorations). The `isSpawned()` check in the filter handles this — we only see what's currently visible.
+
+### Transport GOs
+
+Ships and zeppelins (`GAMEOBJECT_TYPE_MO_TRANSPORT`) are special — they move. A bot on a boat might detect the boat itself as a nearby GO. Filter these by checking `go->GetGoType() == GAMEOBJECT_TYPE_MO_TRANSPORT` and either skip them or handle them as a special "travel" flavor event.
+
+### Duplicate Names
+
+Many GOs share the same name across different entries (e.g., "Campfire" appears hundreds of times with different entries). The anti-repetition system should use the GO **name** (not entry) for cooldown keys to avoid commenting on "Campfire" repeatedly even when the entries differ.
+
+### Dense Decoration Areas
+
+Cities and some dungeons have very high GO density. The scan might return 30+ objects. Always limit the objects sent to the LLM (pick 1-3 most interesting) and summarize the rest as context ("among various other crafting tools and furnishings").
+
+### Instanced vs Open World
+
+In instances (dungeons/raids), GO spawns are per-instance. In the open world, they're shared. This doesn't affect our scanning, but it matters for the LLM context — dungeon GOs are more "special" and worth commenting on, while open-world GOs might be more mundane.
+
+---
+
+## Implementation Complexity
+
+| Component | Scope | Difficulty |
+|-----------|-------|-----------|
+| C++ GO scan + filter | New function in LLMChatterScript.cpp | Low — proven patterns |
+| C++ timer/trigger logic | Extension of existing WorldScript | Low |
+| C++ event insertion | Same pattern as all other events | Low |
+| Python prompt builder | New function in chatter_group.py | Low-Medium |
+| Anti-repetition system | Extension of existing cooldown maps | Low |
+| GO type classification | Static config/map | Low |
+| Class/profession affinity | Optional enhancement | Low |
+| Movement-based triggering | Small addition to timer logic | Low |
+
+**Total: Low complexity.** This feature reuses existing infrastructure end-to-end and adds only the scan logic and a new prompt builder. No schema changes needed beyond a new event type ENUM value.
+
+---
+
+## Summary
+
+This feature is a natural fit for mod-llm-chatter. The APIs exist, the patterns are proven, the performance cost is negligible, and the creative output would add significant life to travel and exploration. Bots that notice their surroundings transform silent travel into an immersive experience where your group feels aware and present in the world.


### PR DESCRIPTION
Added findings from AzerothCore source research and architecture review:
- Raid awareness as prerequisite before BG work (group types, sub-group scoping)
- Dual-worker model: raid worker (epic crowd) + group worker (intimate squad)
- Corrected BattlegroundTypeId enum values from upstream source
- Full AllBattlegroundScript hook inventory (17 hooks) with signatures
- Additional PlayerScript BG-specific hooks (join/leave/desertion)
- BG queue/join transition flow and concerns
- Dynamic scaling philosophy: constant volume regardless of raid size
- Technical gotchas: TeamId vs PvPTeamId, anti-repetition instance ID, AV loot exception

https://claude.ai/code/session_01GxZKt1SEaTXy6LeCDWDKyf