### PR TITLE
fix: ensure targeted NPC speaks first in player-initiated conversations

### DIFF
--- a/tools/chatter_proximity.py
+++ b/tools/chatter_proximity.py
@@ -886,24 +886,6 @@ def handle_proximity_player_conversation(
         label='proximity_player_conversation',
     )
 
-    # If the player targeted a specific entity, the
-    # first line MUST come from that speaker.  Discard
-    # the whole conversation and fall back to a single
-    # line from the target rather than reorder (which
-    # would break conversational coherence).
-    addressed = extra.get('addressed_name', '')
-    if addressed and parsed:
-        first_name = parsed[0].get('name', '')
-        if first_name != addressed:
-            logger.warning(
-                "proximity_player_conversation "
-                "event %s: LLM assigned first line "
-                "to %s instead of addressed %s — "
-                "falling back to single line",
-                event_id, first_name, addressed,
-            )
-            parsed = []
-
     inserted = 0
     cumulative_delay = 0
     for index, line in enumerate(parsed):

--- a/tools/chatter_proximity.py
+++ b/tools/chatter_proximity.py
@@ -688,6 +688,11 @@ def _player_say_conversation_prompt(
             f"The player ({player_name}) is "
             f"addressing {addressed} directly."
         )
+        lines.append(
+            f"IMPORTANT: The FIRST message in the "
+            f"array MUST be spoken by {addressed}, "
+            f"since the player is talking to them."
+        )
     lines.append(
         f"A nearby player ({player_name}) said: "
         f"{player_message}"
@@ -880,6 +885,17 @@ def handle_proximity_player_conversation(
         parsed,
         label='proximity_player_conversation',
     )
+
+    # Enforce that the addressed (targeted) speaker
+    # speaks first — reorder if the LLM ignored it.
+    addressed = extra.get('addressed_name', '')
+    if addressed and parsed:
+        first_name = parsed[0].get('name', '')
+        if first_name != addressed:
+            for i, line in enumerate(parsed):
+                if line.get('name', '') == addressed:
+                    parsed.insert(0, parsed.pop(i))
+                    break
 
     inserted = 0
     cumulative_delay = 0

--- a/tools/chatter_proximity.py
+++ b/tools/chatter_proximity.py
@@ -886,16 +886,23 @@ def handle_proximity_player_conversation(
         label='proximity_player_conversation',
     )
 
-    # Enforce that the addressed (targeted) speaker
-    # speaks first — reorder if the LLM ignored it.
+    # If the player targeted a specific entity, the
+    # first line MUST come from that speaker.  Discard
+    # the whole conversation and fall back to a single
+    # line from the target rather than reorder (which
+    # would break conversational coherence).
     addressed = extra.get('addressed_name', '')
     if addressed and parsed:
         first_name = parsed[0].get('name', '')
         if first_name != addressed:
-            for i, line in enumerate(parsed):
-                if line.get('name', '') == addressed:
-                    parsed.insert(0, parsed.pop(i))
-                    break
+            logger.warning(
+                "proximity_player_conversation "
+                "event %s: LLM assigned first line "
+                "to %s instead of addressed %s — "
+                "falling back to single line",
+                event_id, first_name, addressed,
+            )
+            parsed = []
 
     inserted = 0
     cumulative_delay = 0


### PR DESCRIPTION
## Summary

- When a player targets a specific NPC/humanoid and sends a `/say` message that triggers a multi-speaker conversation, the LLM could assign the first response line to a different speaker than the one the player is addressing.
- Adds an explicit prompt instruction in `_player_say_conversation_prompt` telling the LLM that the **first message in the array MUST be spoken by the addressed entity**, since the player is talking to them.

## Test plan

- [ ] Target an NPC and `/say` something — verify the targeted NPC speaks first in multi-speaker conversations
- [ ] Send `/say` without targeting anyone — verify conversations still work normally (no `addressed_name` set, no extra instruction added)
- [ ] Target an NPC and `/say` something that triggers a single-speaker response — verify it still works as before

https://claude.ai/code/session_01N9Tg3ojzxJGKZfSjRLRVzo