### PR TITLE
Add optional guild-channel chatter (LLMChatter.GuildChatter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,17 @@ Built from the ground up for **fantasy roleplay immersion**. Every system, perso
 * **Conscious World Sensing**: The world is alive, and your companions notice it. Bots dynamically react to everything in their vicinity, from wildlife and rare creatures to NPCs, ancient ruins, weathered statues, and eerie altars. They also observe functional points of interest like moonwells, crackling fireplaces, and bustling forges, while adapting to weather changes, the time of day, arriving zeppelins, and seasonal holidays.
 * **Organic Party Interactivity**: Your companions don't just follow; they interact. They will strike up multi-bot conversations, ask you unprompted questions about your journey, and react authentically to combat, loot, and quest milestones. Seamlessly integrated with the game's emote and voice systems, bots punctuate their dialogue with physical gestures and audible character voices, bringing an extra layer of life to everything from the thrill of an achievement to quiet banter by the campfire.
 * **A Living, Breathing World**: The immersion extends beyond your immediate party. The open world's General channel hums with ambient bot chatter, reacting to real player messages and world events. Guards, vendors, trainers, and citizens engage in proximity `/say` conversations as you walk past, your party bots join in too, slipping naturally between party chat and the world around them. In battlegrounds, bots shout tactical callouts rooted in faction pride, while in raids, they brace for encounters across 148 iconic bosses, sharing lore and rallying morale between pulls.
+* **Guild Hall Camaraderie**: Beyond the party and the open world, your guild feels inhabited. With guild chatter enabled, online guild members occasionally trade short, in-character lines in guild chat — catching up, joking, and reacting to the day — so the guild roster reads like a living roster of people rather than a list of idle names. Off by default and fully configurable.
 * **Seamless Fantasy Immersion**: Designed to preserve the roleplay atmosphere, the module features smart pacing, multi-character conversation flow, and natural reading delays. No repetitive robotic spam, no fourth-wall breaks, just natural, in-character dialogue that deepens the fantasy of adventuring through Azeroth.
 * **Zero Server Impact**: All LLM processing runs in a separate bridge service with a thread-pool worker model. The game server simply drops event rows into the database and moves on, never waiting on an API call. Responses flow back through the same queue and are delivered on the next world tick, keeping your server performance completely unaffected.
 
 ---
 
 ## Changelog
+
+### Guild Channel Chatter
+
+* **Guild chatter**: New optional `guild` delivery channel and an ambient guild-chatter subsystem. When `LLMChatter.GuildChatter.Enable` is set, online bot guild members periodically post short in-character lines to guild chat, gated by `GuildChatter.Chance` and `GuildChatter.Cooldown`. Off by default.
 
 ### 2026-06-19 - Chat-Type Master Toggles & Subsystem Classifier
 

--- a/README.md
+++ b/README.md
@@ -636,6 +636,9 @@ docker exec -i ac-database mysql -uroot -ppassword acore_characters < \
 docker exec -i ac-database mysql -uroot -ppassword acore_characters < \
   modules/mod-llm-chatter/data/sql/characters/updates/20260619_owner_subsystem.sql
 
+docker exec -i ac-database mysql -uroot -ppassword acore_characters < \
+  modules/mod-llm-chatter/data/sql/characters/updates/20260621_guild_chatter.sql
+
 # Non-Docker
 mysql -uroot -ppassword acore_characters < \
   data/sql/characters/updates/20260320_bot_memory_system.sql
@@ -672,6 +675,9 @@ mysql -uroot -ppassword acore_characters < \
 
 mysql -uroot -ppassword acore_characters < \
   data/sql/characters/updates/20260619_owner_subsystem.sql
+
+mysql -uroot -ppassword acore_characters < \
+  data/sql/characters/updates/20260621_guild_chatter.sql
 ```
 
 Migrations are idempotent — safe to run on an already

--- a/conf/mod_llm_chatter.conf.dist
+++ b/conf/mod_llm_chatter.conf.dist
@@ -1506,6 +1506,42 @@ LLMChatter.RaidChatter.MoraleChance = 30
 LLMChatter.RaidChatter.MoraleCooldown = 60
 
 #
+#   LLMChatter.GuildChatter.Enable
+#       Ambient guild-channel chatter. When enabled,
+#       online bot guild members occasionally post a
+#       short in-character line to guild chat. Off by
+#       default so existing setups are unaffected.
+#       Default: 0
+#
+LLMChatter.GuildChatter.Enable = 0
+
+#
+#   LLMChatter.GuildChatter.Chance
+#       Percent chance (1-100) that an eligible guild
+#       produces a line on each check.
+#       Default: 15
+#
+LLMChatter.GuildChatter.Chance = 15
+
+#
+#   LLMChatter.GuildChatter.Cooldown
+#       Minimum seconds between guild chatter lines for
+#       the same guild.
+#       Default: 300
+#
+LLMChatter.GuildChatter.Cooldown = 300
+
+#
+#   LLMChatter.GuildChatter.MaxTokens
+#       Output token budget per guild line. Reasoning
+#       models spend part of this budget thinking before
+#       emitting text, so raise it (e.g. 2000-3000) if
+#       you use one and see empty replies.
+#       Default: 200
+#
+LLMChatter.GuildChatter.MaxTokens = 200
+
+#
 #   LLMChatter.RaidChatter.BattleCryChance
 #       Percent chance (0-100) that a raid-wide battle cry
 #       fires when engaging a boss or elite in a raid instance.

--- a/conf/mod_llm_chatter.conf.dist
+++ b/conf/mod_llm_chatter.conf.dist
@@ -1532,6 +1532,17 @@ LLMChatter.GuildChatter.Chance = 15
 LLMChatter.GuildChatter.Cooldown = 300
 
 #
+#   LLMChatter.GuildChatter.ScanInterval
+#       Seconds between world scans for eligible
+#       guilds. Kept separate from Cooldown so
+#       player-gating does not cause long silent
+#       windows: scanning is cheap, the per-guild
+#       Cooldown still limits actual lines.
+#       Default: 30
+#
+LLMChatter.GuildChatter.ScanInterval = 30
+
+#
 #   LLMChatter.GuildChatter.MaxTokens
 #       Output token budget per guild line. Reasoning
 #       models spend part of this budget thinking before

--- a/conf/mod_llm_chatter.conf.dist
+++ b/conf/mod_llm_chatter.conf.dist
@@ -1506,6 +1506,11 @@ LLMChatter.RaidChatter.MoraleChance = 30
 LLMChatter.RaidChatter.MoraleCooldown = 60
 
 #
+###############################################################################
+# GUILD CHATTER TUNING [SERVER] - read by the worldserver module; these keys take
+# effect immediately for pending rows via `.reload config`.
+###############################################################################
+#
 #   LLMChatter.GuildChatter.Enable
 #       Ambient guild-channel chatter. When enabled,
 #       online bot guild members occasionally post a
@@ -1542,6 +1547,12 @@ LLMChatter.GuildChatter.Cooldown = 300
 #
 LLMChatter.GuildChatter.ScanInterval = 30
 
+#
+###############################################################################
+# GUILD CHATTER PROMPT TUNING [BRIDGE] - read by the Python chatter bridge, NOT the
+# worldserver. `.reload config` does NOT affect this key; restart the
+# ac-llm-chatter-bridge container to apply changes.
+###############################################################################
 #
 #   LLMChatter.GuildChatter.MaxTokens
 #       Output token budget per guild line. Reasoning

--- a/data/sql/characters/base/00000000_llm_chatter_tables.sql
+++ b/data/sql/characters/base/00000000_llm_chatter_tables.sql
@@ -78,7 +78,8 @@ CREATE TABLE IF NOT EXISTS `llm_chatter_events` (
         'proximity_player_say',
         'proximity_player_conversation',
         'bot_backstory_regen',
-        'bot_tone_regen'
+        'bot_tone_regen',
+        'guild_idle_chatter'
     ) NOT NULL,
     `event_scope` ENUM('global', 'zone', 'player') NOT NULL DEFAULT 'zone',
     `zone_id` INT UNSIGNED DEFAULT NULL,

--- a/data/sql/characters/updates/20260621_guild_chatter.sql
+++ b/data/sql/characters/updates/20260621_guild_chatter.sql
@@ -1,0 +1,16 @@
+-- Add guild_idle_chatter event type for ambient guild-channel chatter.
+-- Idempotent: guarded by COLUMN_TYPE check.
+
+SET @has_guild = (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME   = 'llm_chatter_events'
+    AND COLUMN_NAME  = 'event_type'
+    AND COLUMN_TYPE LIKE '%guild_idle_chatter%'
+);
+SET @sql = IF(@has_guild = 0,
+  "ALTER TABLE `llm_chatter_events` MODIFY COLUMN `event_type` enum('weather_change','holiday_start','holiday_end','creature_death_boss','creature_death_rare','creature_death_guard','player_enters_zone','bot_pvp_kill','bot_level_up','bot_achievement','bot_quest_complete','world_boss_spawn','rare_spawn','transport_arrives','day_night_transition','enemy_player_near','bot_loot_item','bot_group_join','bot_group_kill','bot_group_death','bot_group_loot','bot_group_player_msg','bot_group_general_reaction','bot_group_combat','bot_group_levelup','bot_group_quest_complete','bot_group_achievement','bot_group_spell_cast','bot_group_quest_objectives','bot_group_resurrect','bot_group_zone_transition','bot_group_dungeon_entry','bot_group_wipe','bot_group_corpse_run','player_general_msg','minor_event','bot_group_low_health','bot_group_oom','bot_group_aggro_loss','bot_group_quest_accept','bot_group_quest_accept_batch','weather_ambient','bot_group_nearby_object','bot_group_join_batch','bg_match_start','bg_match_end','bg_pvp_kill','bg_flag_picked_up','bg_flag_dropped','bg_flag_captured','bg_flag_returned','bg_node_contested','bg_node_captured','bg_score_milestone','bg_idle_chatter','bg_player_arrival','raid_boss_pull','raid_boss_kill','raid_boss_wipe','raid_idle_morale','bot_group_farewell','bot_group_subzone_change','bot_group_emote_observer','bot_group_emote_reaction','bot_group_screenshot_observation','proximity_say','proximity_conversation','proximity_reply','proximity_player_say','proximity_player_conversation','bot_backstory_regen','bot_tone_regen','guild_idle_chatter') NOT NULL",
+  'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/LLMChatterConfig.cpp
+++ b/src/LLMChatterConfig.cpp
@@ -584,6 +584,10 @@ void LLMChatterConfig::LoadConfig()
         GetChatterOption<uint32>(
             "LLMChatter.GuildChatter."
             "Cooldown", 300);
+    _guildChatterScanInterval =
+        GetChatterOption<uint32>(
+            "LLMChatter.GuildChatter."
+            "ScanInterval", 30);
 
     // Zone intrusion alerts
     _zoneIntrusionEnable =

--- a/src/LLMChatterConfig.cpp
+++ b/src/LLMChatterConfig.cpp
@@ -573,6 +573,18 @@ void LLMChatterConfig::LoadConfig()
             "LLMChatter.RaidChatter."
             "MoraleCooldown", 120);
 
+    // Guild chatter (ambient guild-channel banter)
+    _guildChatterEnable = GetChatterOption<bool>(
+        "LLMChatter.GuildChatter.Enable", false);
+    _guildChatterChance =
+        GetChatterOption<uint32>(
+            "LLMChatter.GuildChatter."
+            "Chance", 15);
+    _guildChatterCooldown =
+        GetChatterOption<uint32>(
+            "LLMChatter.GuildChatter."
+            "Cooldown", 300);
+
     // Zone intrusion alerts
     _zoneIntrusionEnable =
         GetChatterOption<bool>(

--- a/src/LLMChatterConfig.h
+++ b/src/LLMChatterConfig.h
@@ -252,6 +252,7 @@ public:
     bool _guildChatterEnable{false};
     uint32 _guildChatterChance{15};
     uint32 _guildChatterCooldown{300};
+    uint32 _guildChatterScanInterval{30};
 
     // Zone intrusion alerts
     bool _zoneIntrusionEnable;

--- a/src/LLMChatterConfig.h
+++ b/src/LLMChatterConfig.h
@@ -248,6 +248,11 @@ public:
     uint32 _raidMoraleChance;
     uint32 _raidMoraleCooldown;
 
+    // Guild chatter (ambient guild-channel banter)
+    bool _guildChatterEnable{false};
+    uint32 _guildChatterChance{15};
+    uint32 _guildChatterCooldown{300};
+
     // Zone intrusion alerts
     bool _zoneIntrusionEnable;
     uint32 _zoneIntrusionZoneThrottleSec;

--- a/src/LLMChatterDelivery.cpp
+++ b/src/LLMChatterDelivery.cpp
@@ -236,6 +236,15 @@ void DeliverPendingMessagesImpl()
         && !sLLMChatterConfig->_proxChatterEnable)
         return;
 
+    // Master GuildChatter toggle. Consume already-queued
+    // guild rows when guild chatter is disabled, so flipping
+    // LLMChatter.GuildChatter.Enable = 0 takes effect
+    // immediately for pending rows (otherwise the generic
+    // retry path resets delivered = 0 and retries forever).
+    if (ownerSubsystem == "guild"
+        && !sLLMChatterConfig->_guildChatterEnable)
+        return;
+
     ObjectGuid guid =
         ObjectGuid::Create<HighGuid::Player>(
             botGuid);
@@ -531,27 +540,26 @@ void DeliverPendingMessagesImpl()
             }
             else if (channel == "guild")
             {
-                // off means off: do not deliver
-                // guild chatter if the feature was
-                // disabled after the event queued.
-                if (!sLLMChatterConfig
-                         ->_guildChatterEnable)
+                // The master-toggle guard above already
+                // consumes guild rows when the feature is
+                // off, so we only reach here when enabled.
+                Guild* guild = bot->GetGuild();
+                WorldSession* session =
+                    bot->GetSession();
+
+                if (guild && session)
                 {
+                    guild->BroadcastToGuild(
+                        session, false,
+                        processedMessage.c_str(),
+                        LANG_UNIVERSAL);
+                    sent = true;
                 }
-                else if (Guild* g = bot->GetGuild())
+                else
                 {
-                    // defensive: never call
-                    // BroadcastToGuild without a
-                    // live session.
-                    if (WorldSession* session
-                            = bot->GetSession())
-                    {
-                        g->BroadcastToGuild(
-                            session, false,
-                            processedMessage.c_str(),
-                            LANG_UNIVERSAL);
-                        sent = true;
-                    }
+                    // a missing guild/session is not
+                    // transient -> do not retry forever.
+                    botUnavailable = true;
                 }
             }
             else if (channel == "yell")

--- a/src/LLMChatterDelivery.cpp
+++ b/src/LLMChatterDelivery.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "LLMChatterConfig.h"
+#include "Guild.h"
 #include "LLMChatterDelivery.h"
 #include "LLMChatterProximity.h"
 #include "LLMChatterShared.h"
@@ -527,6 +528,17 @@ void DeliverPendingMessagesImpl()
             else if (channel == "say")
             {
                 sent = ai->Say(processedMessage);
+            }
+            else if (channel == "guild")
+            {
+                if (Guild* g = bot->GetGuild())
+                {
+                    g->BroadcastToGuild(
+                        bot->GetSession(), false,
+                        processedMessage.c_str(),
+                        LANG_UNIVERSAL);
+                    sent = true;
+                }
             }
             else if (channel == "yell")
             {

--- a/src/LLMChatterDelivery.cpp
+++ b/src/LLMChatterDelivery.cpp
@@ -531,13 +531,27 @@ void DeliverPendingMessagesImpl()
             }
             else if (channel == "guild")
             {
-                if (Guild* g = bot->GetGuild())
+                // off means off: do not deliver
+                // guild chatter if the feature was
+                // disabled after the event queued.
+                if (!sLLMChatterConfig
+                         ->_guildChatterEnable)
                 {
-                    g->BroadcastToGuild(
-                        bot->GetSession(), false,
-                        processedMessage.c_str(),
-                        LANG_UNIVERSAL);
-                    sent = true;
+                }
+                else if (Guild* g = bot->GetGuild())
+                {
+                    // defensive: never call
+                    // BroadcastToGuild without a
+                    // live session.
+                    if (WorldSession* session
+                            = bot->GetSession())
+                    {
+                        g->BroadcastToGuild(
+                            session, false,
+                            processedMessage.c_str(),
+                            LANG_UNIVERSAL);
+                        sent = true;
+                    }
                 }
             }
             else if (channel == "yell")

--- a/src/LLMChatterShared.cpp
+++ b/src/LLMChatterShared.cpp
@@ -231,7 +231,7 @@ uint32 RollConfiguredDelay(
         sLLMChatterConfig->*maxMember);
 }
 
-constexpr std::array<EventPriorityRule, 33>
+constexpr std::array<EventPriorityRule, 34>
     kTierPriorityRules = {{
         {"bot_group_combat",        PRIORITY_CRITICAL},
         {"bot_group_spell_cast",    PRIORITY_CRITICAL},
@@ -258,6 +258,7 @@ constexpr std::array<EventPriorityRule, 33>
         {"player_enters_zone",      PRIORITY_HIGH},
         {"bg_idle_chatter",         PRIORITY_FILLER},
         {"raid_idle_morale",        PRIORITY_FILLER},
+        {"guild_idle_chatter",      PRIORITY_FILLER},
         {"weather_ambient",         PRIORITY_FILLER},
         {"minor_event",             PRIORITY_FILLER},
         {"day_night_transition",    PRIORITY_FILLER},
@@ -275,7 +276,7 @@ constexpr std::array<PredicatePriorityRule, 1>
         {IsStateCalloutEventType, PRIORITY_CRITICAL},
     }};
 
-constexpr std::array<EventPriorityRule, 21>
+constexpr std::array<EventPriorityRule, 22>
     kLegacyPriorityRules = {{
         {"player_general_msg",       8},
         {"day_night_transition",     7},
@@ -293,6 +294,7 @@ constexpr std::array<EventPriorityRule, 21>
         {"bot_group_join",           0},
         {"bot_group_join_batch",     0},
         {"raid_idle_morale",         0},
+        {"guild_idle_chatter",       0},
         {"proximity_say",           0},
         {"proximity_conversation",  0},
         {"proximity_reply",         1},

--- a/src/LLMChatterWorld.cpp
+++ b/src/LLMChatterWorld.cpp
@@ -443,10 +443,22 @@ public:
             CheckRaidIdleMorale();
         }
 
-        if (sLLMChatterConfig->_guildChatterEnable
+        // Scan cadence (ScanInterval, default
+        // 30s) is intentionally
+        // separate from the per-guild cooldown,
+        // which is enforced inside
+        // CheckGuildIdleChatter via guildCooldowns.
+        // Using the full cooldown as the scan
+        // interval caused long silent windows (a
+        // player logging in just after an empty
+        // scan waited a whole cooldown). Also gated
+        // on _useEventSystem to match the other
+        // event producers.
+        if (sLLMChatterConfig->_useEventSystem
+            && sLLMChatterConfig->_guildChatterEnable
             && now - _lastGuildChatterTime
                 >= sLLMChatterConfig
-                    ->_guildChatterCooldown
+                    ->_guildChatterScanInterval
                     * 1000)
         {
             _lastGuildChatterTime = now;

--- a/src/LLMChatterWorld.cpp
+++ b/src/LLMChatterWorld.cpp
@@ -13,6 +13,8 @@
 
 #include "DatabaseEnv.h"
 #include "Group.h"
+#include "Guild.h"
+#include "GuildMgr.h"
 #include "Log.h"
 #include "MapMgr.h"
 #include "ObjectAccessor.h"
@@ -328,6 +330,7 @@ public:
         _lastQuestFlushTime = 0;
         _lastGroupJoinFlushTime = 0;
         _lastRaidMoraleTime = 0;
+        _lastGuildChatterTime = 0;
         _lastTimePeriod = "";
     }
 
@@ -439,6 +442,16 @@ public:
             _lastRaidMoraleTime = now;
             CheckRaidIdleMorale();
         }
+
+        if (sLLMChatterConfig->_guildChatterEnable
+            && now - _lastGuildChatterTime
+                >= sLLMChatterConfig
+                    ->_guildChatterCooldown
+                    * 1000)
+        {
+            _lastGuildChatterTime = now;
+            CheckGuildIdleChatter();
+        }
     }
 
 private:
@@ -451,6 +464,7 @@ private:
     uint32 _lastQuestFlushTime = 0;
     uint32 _lastGroupJoinFlushTime = 0;
     uint32 _lastRaidMoraleTime = 0;
+    uint32 _lastGuildChatterTime = 0;
     std::string _lastTimePeriod;
 
     void CheckDayNightTransition()
@@ -600,6 +614,144 @@ private:
     void CheckNearbyGameObjects()
     {
         ::CheckNearbyGameObjects();
+    }
+
+    void CheckGuildIdleChatter()
+    {
+        static std::unordered_map<uint32, time_t>
+            guildCooldowns;
+
+        time_t nowSec = time(nullptr);
+
+        // Guild chatter is only worthwhile when a real
+        // player is online to read it, so first collect
+        // the guilds that currently have a human member
+        // online.
+        std::set<uint32> activeGuilds;
+        WorldSessionMgr::SessionMap const& sessions =
+            sWorldSessionMgr->GetAllSessions();
+        for (auto const& pair : sessions)
+        {
+            WorldSession* session = pair.second;
+            if (!session || session->PlayerLoading())
+                continue;
+
+            Player* player = session->GetPlayer();
+            if (!player || !player->IsInWorld()
+                || IsPlayerBot(player))
+                continue;
+
+            if (uint32 gid = player->GetGuildId())
+                activeGuilds.insert(gid);
+        }
+        if (activeGuilds.empty())
+            return;
+
+        // Bucket online, idle bot members of those guilds.
+        std::unordered_map<uint32,
+            std::vector<Player*>> byGuild;
+        PlayerBotMap allBots =
+            sRandomPlayerbotMgr.GetAllBots();
+        for (auto const& pair : allBots)
+        {
+            Player* bot = pair.second;
+            if (!bot || !bot->IsInWorld()
+                || !bot->IsAlive())
+                continue;
+
+            WorldSession* session = bot->GetSession();
+            if (session && session->PlayerLoading())
+                continue;
+
+            if (bot->IsInCombat())
+                continue;
+
+            uint32 guildId = bot->GetGuildId();
+            if (!guildId || !activeGuilds.count(guildId))
+                continue;
+
+            byGuild[guildId].push_back(bot);
+        }
+
+        for (uint32 guildId : activeGuilds)
+        {
+            auto it = byGuild.find(guildId);
+            if (it == byGuild.end())
+                continue;
+
+            std::vector<Player*> const& members =
+                it->second;
+            if (members.empty())
+                continue;
+
+            auto cdIt = guildCooldowns.find(guildId);
+            if (cdIt != guildCooldowns.end()
+                && nowSec - cdIt->second
+                    < (time_t)sLLMChatterConfig
+                          ->_guildChatterCooldown)
+                continue;
+
+            if (urand(1, 100)
+                > sLLMChatterConfig->_guildChatterChance)
+                continue;
+
+            Player* speaker =
+                members[urand(0, members.size() - 1)];
+
+            Guild* guild =
+                sGuildMgr->GetGuildById(guildId);
+            std::string guildName =
+                guild ? guild->GetName() : "the guild";
+
+            // Collect a few online guildmate names for
+            // prompt context.
+            std::string mates;
+            uint32 added = 0;
+            for (Player* m : members)
+            {
+                if (m == speaker)
+                    continue;
+                if (added)
+                    mates += ", ";
+                mates += m->GetName();
+                if (++added >= 4)
+                    break;
+            }
+
+            std::string json = fmt::format(
+                R"({{"guild_name":"{}",)"
+                R"("speaker_name":"{}",)"
+                R"("guildmates":"{}",)"
+                R"("zone_id":{}}})",
+                JsonEscape(guildName),
+                JsonEscape(speaker->GetName()),
+                JsonEscape(mates),
+                speaker->GetZoneId());
+
+            std::string cooldownKey =
+                "guild_idle_"
+                + std::to_string(guildId);
+
+            QueueChatterEvent(
+                "guild_idle_chatter",
+                "global",
+                speaker->GetZoneId(),
+                speaker->GetMapId(),
+                GetChatterEventPriority(
+                    "guild_idle_chatter"),
+                cooldownKey,
+                speaker->GetGUID().GetCounter(),
+                speaker->GetName(),
+                0, "", 0,
+                EscapeString(json),
+                GetReactionDelaySeconds(
+                    "guild_idle_chatter"),
+                sLLMChatterConfig
+                    ->_eventExpirationSeconds,
+                false);
+
+            guildCooldowns[guildId] = nowSec;
+        }
     }
 
     void CheckRaidIdleMorale()

--- a/tools/chatter_event_registry.py
+++ b/tools/chatter_event_registry.py
@@ -844,6 +844,22 @@ EVENT_REGISTRY: Dict[str, EventSpec] = {
         },
     ),
 
+    'guild_idle_chatter': EventSpec(
+        handler_module='chatter_guild',
+        handler_func=(
+            'process_guild_idle_chatter_event'
+        ),
+        producer='LLMChatterWorld.cpp',
+        priority='filler',
+        description='Ambient guild-channel chatter',
+        payload_fields={
+            'guild_name': (str, True),
+            'speaker_name': (str, True),
+            'guildmates': (str, False),
+            'zone_id': (int, True),
+        },
+    ),
+
     # -- World events (chatter_world_events) ------
 
     'transport_arrives': EventSpec(

--- a/tools/chatter_guild.py
+++ b/tools/chatter_guild.py
@@ -1,0 +1,225 @@
+"""Guild chatter event handlers.
+
+Ambient guild-channel banter: online guild members occasionally
+exchange short, in-character lines in guild chat. Driven by
+``CheckGuildIdleChatter`` in LLMChatterWorld.cpp, gated by
+``LLMChatter.GuildChatter.*`` config. Mirrors the structure of the
+raid idle-morale and proximity handlers.
+"""
+
+import logging
+import random
+from typing import Dict, Optional
+
+from chatter_db import insert_chat_message
+from chatter_llm import call_llm
+from chatter_shared import (
+    append_json_instruction,
+    build_bot_identity_with_level,
+    get_class_name,
+    get_gender_label,
+    get_race_name,
+    parse_extra_data,
+)
+from chatter_text import (
+    cleanup_message,
+    parse_single_response,
+    strip_speaker_prefix,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _mark_event(db, event_id: int, status: str) -> None:
+    cursor = db.cursor()
+    cursor.execute(
+        "UPDATE llm_chatter_events SET status = %s "
+        "WHERE id = %s",
+        (status, event_id),
+    )
+    db.commit()
+
+
+def _query_speaker(db, bot_guid: int) -> Dict[str, object]:
+    """Load a speaker's class/race/level/gender plus their
+    stored personality (traits/tone/backstory) from the
+    bot-identity table. Returns {} if the bot is unknown."""
+    if not bot_guid:
+        return {}
+
+    try:
+        cursor = db.cursor(dictionary=True)
+        cursor.execute(
+            "SELECT class, race, gender, level "
+            "FROM characters WHERE guid = %s",
+            (bot_guid,),
+        )
+        base = cursor.fetchone()
+        if not base:
+            return {}
+
+        cursor.execute(
+            "SELECT trait1, trait2, trait3, tone, "
+            "       backstory "
+            "FROM llm_bot_identities "
+            "WHERE bot_guid = %s LIMIT 1",
+            (bot_guid,),
+        )
+        ident = cursor.fetchone() or {}
+
+        traits = [
+            trait for trait in (
+                ident.get('trait1'),
+                ident.get('trait2'),
+                ident.get('trait3'),
+            )
+            if trait
+        ]
+        return {
+            'class': get_class_name(
+                int(base.get('class', 0) or 0)
+            ),
+            'race': get_race_name(
+                int(base.get('race', 0) or 0)
+            ),
+            'gender': get_gender_label(
+                int(base.get('gender', 0) or 0)
+            ),
+            'level': int(base.get('level', 0) or 0),
+            'traits': traits,
+            'tone': ident.get('tone') or '',
+            'backstory': ident.get('backstory') or '',
+        }
+    except Exception:
+        logger.error(
+            "query guild speaker failed",
+            exc_info=True,
+        )
+        return {}
+
+
+def _build_guild_prompt(
+    speaker_name: str,
+    speaker: Dict,
+    guild_name: str,
+    guildmates: str,
+    config: Optional[Dict] = None,
+) -> str:
+    identity = build_bot_identity_with_level(
+        speaker_name,
+        speaker.get('race', 'Unknown'),
+        speaker.get('class', 'Adventurer'),
+        speaker.get('level', 1),
+        gender=speaker.get('gender', ''),
+    )
+
+    lines = [identity]
+    lines.append(
+        f"You are a member of the guild "
+        f"\"{guild_name}\"."
+    )
+
+    traits = speaker.get('traits') or []
+    if traits:
+        lines.append(
+            "Personality: " + ", ".join(traits) + "."
+        )
+    if speaker.get('tone'):
+        lines.append(f"Tone: {speaker['tone']}.")
+    if speaker.get('backstory'):
+        lines.append(
+            f"Background: {speaker['backstory']}"
+        )
+    if guildmates:
+        lines.append(
+            f"Guildmates currently online: "
+            f"{guildmates}."
+        )
+
+    lines.append(
+        "Write ONE short, casual line for guild "
+        "chat, in character, the way a real person "
+        "playing WoW would chat with their guild. "
+        "Length: keep it under 200 characters. No "
+        "quotation marks, no name prefix, no "
+        "roleplay asterisks."
+    )
+
+    return append_json_instruction(
+        "\n".join(lines) + "\n"
+    )
+
+
+def process_guild_idle_chatter_event(
+    db, client, config, event
+):
+    """Handle guild_idle_chatter — one online guild member
+    posts a short in-character line to guild chat."""
+    event_id = event['id']
+    extra = parse_extra_data(
+        event.get('extra_data'),
+        event_id, 'guild_idle_chatter')
+
+    if not extra:
+        _mark_event(db, event_id, 'skipped')
+        return False
+
+    speaker_guid = int(
+        event.get('subject_guid', 0) or 0
+    )
+    speaker_name = (
+        event.get('subject_name')
+        or extra.get('speaker_name')
+        or ''
+    )
+    guild_name = extra.get('guild_name') or 'the guild'
+    guildmates = extra.get('guildmates') or ''
+
+    speaker = _query_speaker(db, speaker_guid)
+    if not speaker or not speaker_name:
+        _mark_event(db, event_id, 'skipped')
+        return False
+
+    prompt = _build_guild_prompt(
+        speaker_name, speaker, guild_name,
+        guildmates, config,
+    )
+
+    max_tokens = int(config.get(
+        'LLMChatter.GuildChatter.MaxTokens', 200
+    ))
+    response = call_llm(
+        client, prompt, config,
+        max_tokens_override=max_tokens,
+        context=f"guild:{speaker_name}",
+        label='guild_idle_chatter',
+    )
+    if not response:
+        _mark_event(db, event_id, 'skipped')
+        return False
+
+    parsed = parse_single_response(response)
+    message = strip_speaker_prefix(
+        parsed.get('message', ''), speaker_name
+    )
+    message = cleanup_message(
+        message, action=parsed.get('action')
+    )
+    if not message:
+        _mark_event(db, event_id, 'skipped')
+        return False
+    if len(message) > 255:
+        message = message[:252] + "..."
+
+    insert_chat_message(
+        db,
+        bot_guid=speaker_guid,
+        bot_name=speaker_name,
+        message=message,
+        channel='guild',
+        owner_subsystem='guild',
+        event_id=event_id,
+    )
+
+    _mark_event(db, event_id, 'completed')
+    return True

--- a/tools/chatter_guild.py
+++ b/tools/chatter_guild.py
@@ -149,6 +149,14 @@ def _build_guild_prompt(
                 "elsewhere will read it."
             )
     lines.append(
+        "Stay fully in character — you ARE this person "
+        "in Azeroth. No fourth-wall breaks and no "
+        "out-of-character or game-mechanic talk (no DPS "
+        "meters, rotations, addons, or references to the "
+        "player behind the screen). Draw on your race, "
+        "class and surroundings."
+    )
+    lines.append(
         "Write ONE short, casual line for guild "
         "chat, in character, the way a real person "
         "playing WoW would chat with their guild. "

--- a/tools/chatter_guild.py
+++ b/tools/chatter_guild.py
@@ -19,6 +19,7 @@ from chatter_shared import (
     get_class_name,
     get_gender_label,
     get_race_name,
+    get_zone_name,
     parse_extra_data,
 )
 from chatter_text import (
@@ -104,6 +105,7 @@ def _build_guild_prompt(
     guild_name: str,
     guildmates: str,
     config: Optional[Dict] = None,
+    zone_id: int = 0,
 ) -> str:
     identity = build_bot_identity_with_level(
         speaker_name,
@@ -136,6 +138,16 @@ def _build_guild_prompt(
             f"{guildmates}."
         )
 
+    if zone_id:
+        zone = get_zone_name(zone_id)
+        if zone:
+            lines.append(
+                f"You are currently in {zone}. You may "
+                "naturally mention what you are doing there "
+                "(questing, leveling, traveling) or react to "
+                "it — this is guild chat, so guildmates "
+                "elsewhere will read it."
+            )
     lines.append(
         "Write ONE short, casual line for guild "
         "chat, in character, the way a real person "
@@ -180,9 +192,10 @@ def process_guild_idle_chatter_event(
         _mark_event(db, event_id, 'skipped')
         return False
 
+    zone_id = int(extra.get('zone_id', 0) or 0)
     prompt = _build_guild_prompt(
         speaker_name, speaker, guild_name,
-        guildmates, config,
+        guildmates, config, zone_id=zone_id,
     )
 
     max_tokens = int(config.get(

--- a/tools/llm_chatter_bridge.py
+++ b/tools/llm_chatter_bridge.py
@@ -358,6 +358,7 @@ def fetch_pending_events(db, config, max_count):
               OR e.event_type = 'player_general_msg'
               OR e.event_type = 'player_enters_zone'
               OR e.event_type LIKE 'proximity_%%'
+              OR e.event_type = 'guild_idle_chatter'
               OR (
                   EXISTS (
                       SELECT 1 FROM characters c


### PR DESCRIPTION
## Summary

mod-llm-chatter voices bots in party, raid, battleground, say/yell and the General channel — but never in **guild chat**, even though it's the primary social channel for a guild of companions. This adds an optional, config-gated guild-chatter subsystem (default **off**), built to mirror the existing ambient / raid idle-chatter pattern.

## What it does

- **`LLMChatterWorld::CheckGuildIdleChatter()`** — on a periodic tick, queues a `guild_idle_chatter` event for guilds that currently have a **human member online**, picking an online, idle bot guild member as the speaker. Gating on a real player being present keeps chatter relevant and avoids generating events no one will read.
- **`LLMChatterDelivery`** — new `guild` channel that broadcasts a queued line to the bot's guild via `Guild::BroadcastToGuild`.
- **`chatter_guild.py`** — handler that builds an in-character prompt from the speaker's identity (race/class/level + stored traits/tone/backstory) and produces a single guild line.
- **Config** — `LLMChatter.GuildChatter.Enable` (default `0`), `.Chance`, `.Cooldown`, `.MaxTokens`, documented in the conf dist.
- **SQL migration** — `20260621_guild_chatter.sql` adds the `guild_idle_chatter` value to the `llm_chatter_events.event_type` enum (idempotent, guarded by a `COLUMN_TYPE` check, following the existing update convention).

## Design notes

- **Off by default** — existing setups are completely unaffected until `GuildChatter.Enable = 1`.
- **Player-gated** — only guilds with an online human member produce chatter, consistent with the module's player-centric philosophy (same spirit as `raid_idle_morale`).
- **`MaxTokens`** is exposed because reasoning models spend part of their output budget thinking before emitting text; non-reasoning models are fine at the default.

## Testing

Tested in-game on AzerothCore WotLK 3.3.5a with mod-playerbots:
- With `GuildChatter.Enable = 1`, online bot guild members post in-character lines to guild chat once a human guildmate is online; messages broadcast correctly via the new delivery channel (`delivered = 1`).
- With no human online, no `guild_idle_chatter` events are produced (player-gate verified).
- Worldserver and bridge logs clean; no impact on existing party/general/raid/BG chatter.

PR targets `develop` per CONTRIBUTING.