### PR TITLE
Guild chatter: random subject pool + length variation (roadmap #2 + #5)

### DIFF
--- a/conf/mod_llm_chatter.conf.dist
+++ b/conf/mod_llm_chatter.conf.dist
@@ -1564,6 +1564,21 @@ LLMChatter.GuildChatter.ScanInterval = 30
 LLMChatter.GuildChatter.MaxTokens = 200
 
 #
+#   LLMChatter.GuildChatter.ZoneNameChance
+#       Percent chance (0-100) that a guild line is told to
+#       name the speaker's current zone. Guild chat reaches
+#       guildmates scattered across other zones, so a bot
+#       saying "this swamp" is meaningless to them. The model
+#       cannot be trusted to self-pace this, so the decision
+#       is made per-line by this RNG roll: on a hit the prompt
+#       asks the bot to work the zone name in; on a miss the
+#       prompt forbids referencing the location at all.
+#       Set 0 to never name, 100 to always name.
+#       Default: 20
+#
+LLMChatter.GuildChatter.ZoneNameChance = 20
+
+#
 #   LLMChatter.RaidChatter.BattleCryChance
 #       Percent chance (0-100) that a raid-wide battle cry
 #       fires when engaging a boss or elite in a raid instance.

--- a/src/LLMChatterWorld.cpp
+++ b/src/LLMChatterWorld.cpp
@@ -730,14 +730,23 @@ private:
                     break;
             }
 
+            // PR #30 follow-up #1: pass the authoritative faction from
+            // GetTeamId() so the bridge need not derive it from a race map.
+            const char* teamName =
+                speaker->GetTeamId() == TEAM_ALLIANCE
+                    ? "Alliance"
+                    : "Horde";
+
             std::string json = fmt::format(
                 R"({{"guild_name":"{}",)"
                 R"("speaker_name":"{}",)"
                 R"("guildmates":"{}",)"
+                R"("team":"{}",)"
                 R"("zone_id":{}}})",
                 JsonEscape(guildName),
                 JsonEscape(speaker->GetName()),
                 JsonEscape(mates),
+                teamName,
                 speaker->GetZoneId());
 
             std::string cooldownKey =

--- a/tools/chatter_constants.py
+++ b/tools/chatter_constants.py
@@ -3465,3 +3465,77 @@ REACTION_TONES = {
         "with curiosity",
     ],
 }
+
+
+# =============================================================================
+# GUILD CHAT TOPICS (roadmap #2) — random subject pool for guild idle chatter.
+# Leveling-realistic, everyday-WoW-player flavor (NO endgame/raid/dungeon-run
+# invention — matches the guild prompt's level-appropriate guard). Selected per
+# event and injected as an optional "topic idea" nudge.
+# =============================================================================
+GUILD_CHAT_TOPICS = [
+    "a quest you're stuck on",
+    "a gear upgrade that just dropped",
+    "running low on bag space",
+    "a quest item that just won't drop",
+    "asking if anyone wants to group up",
+    "a brutally long flight path",
+    "a rare mob you just spotted",
+    "skilling up a profession",
+    "needing mats for a profession",
+    "being broke while saving for a mount",
+    "a close call that nearly killed you",
+    "how pretty (or grim) your current zone is",
+    "being lost and asking for quest directions",
+    "a stupid death you just had",
+    "wishing someone could summon you",
+    "what to put your next talent points into",
+    "an elite quest you can't solo",
+    "talking smack about the other faction",
+    "looking for a healer for a dungeon",
+    "an annoying escort quest",
+    "loot envy over a guildmate's drop",
+    "planning to play more this weekend",
+    "stepping away for food real quick",
+    "just dinged a level",
+    "a big vendor-trash haul you just sold",
+    "asking how a class ability works",
+    "corpse-running back after a wipe",
+    "auction house prices being absurd",
+    "your pet or minion acting up",
+    "an NPC with a ridiculous name",
+    "grinding the same mobs over and over",
+    "finally finishing a long quest chain",
+    "getting ganked and wanting revenge",
+    "comparing two gear pieces you can't decide between",
+    "a guildmate who logged on you haven't seen in a while",
+    "repairs eating all your gold",
+    "a quest reward that was totally worth it",
+    "the weather/scenery where you're questing",
+    "wanting to run an instance later tonight",
+    "a near-impossible jumping puzzle or hard-to-reach chest",
+]
+
+# In-character-only variant (used when PersonaMode == 'character').
+GUILD_CHAT_TOPICS_RP = [
+    "the dangers of the road you're traveling",
+    "a rumor overheard in the last town",
+    "your faith, code, or philosophy",
+    "honoring a fallen comrade",
+    "the beauty or menace of the land around you",
+    "a personal vow or quest you carry",
+    "distrust of the opposing faction",
+    "the burden of your calling",
+    "a memory from your homeland",
+    "wariness of the local wildlife",
+    "an omen or strange sight on your path",
+    "gratitude for a guildmate's aid",
+    "the toll of endless fighting",
+    "a prayer or blessing for the guild",
+    "longing for a quieter life",
+    "pride in your craft or lineage",
+    "a warning about a place best avoided",
+    "the changing of the seasons or the hour",
+    "an old legend tied to this region",
+    "resolve before a hard task ahead",
+]

--- a/tools/chatter_constants.py
+++ b/tools/chatter_constants.py
@@ -3469,54 +3469,10 @@ REACTION_TONES = {
 
 # =============================================================================
 # GUILD CHAT TOPICS (roadmap #2) — random subject pool for guild idle chatter.
-# Leveling-realistic, everyday-WoW-player flavor (NO endgame/raid/dungeon-run
-# invention — matches the guild prompt's level-appropriate guard). Selected per
-# event and injected as an optional "topic idea" nudge.
+# Only the in-character RP pool is used; guild chatter runs in character mode
+# and its prompt bans game-mechanic talk. Selected per event and injected as an
+# optional "topic idea" nudge.
 # =============================================================================
-GUILD_CHAT_TOPICS = [
-    "a quest you're stuck on",
-    "a gear upgrade that just dropped",
-    "running low on bag space",
-    "a quest item that just won't drop",
-    "asking if anyone wants to group up",
-    "a brutally long flight path",
-    "a rare mob you just spotted",
-    "skilling up a profession",
-    "needing mats for a profession",
-    "being broke while saving for a mount",
-    "a close call that nearly killed you",
-    "how pretty (or grim) your current zone is",
-    "being lost and asking for quest directions",
-    "a stupid death you just had",
-    "wishing someone could summon you",
-    "what to put your next talent points into",
-    "an elite quest you can't solo",
-    "talking smack about the other faction",
-    "looking for a healer for a dungeon",
-    "an annoying escort quest",
-    "loot envy over a guildmate's drop",
-    "planning to play more this weekend",
-    "stepping away for food real quick",
-    "just dinged a level",
-    "a big vendor-trash haul you just sold",
-    "asking how a class ability works",
-    "corpse-running back after a wipe",
-    "auction house prices being absurd",
-    "your pet or minion acting up",
-    "an NPC with a ridiculous name",
-    "grinding the same mobs over and over",
-    "finally finishing a long quest chain",
-    "getting ganked and wanting revenge",
-    "comparing two gear pieces you can't decide between",
-    "a guildmate who logged on you haven't seen in a while",
-    "repairs eating all your gold",
-    "a quest reward that was totally worth it",
-    "the weather/scenery where you're questing",
-    "wanting to run an instance later tonight",
-    "a near-impossible jumping puzzle or hard-to-reach chest",
-]
-
-# In-character-only variant (used when PersonaMode == 'character').
 GUILD_CHAT_TOPICS_RP = [
     "the dangers of the road you're traveling",
     "a rumor overheard in the last town",
@@ -3538,4 +3494,77 @@ GUILD_CHAT_TOPICS_RP = [
     "the changing of the seasons or the hour",
     "an old legend tied to this region",
     "resolve before a hard task ahead",
+    # --- camaraderie & guild bonds ---
+    "what the guild's banner means to you",
+    "a newcomer who needs looking after",
+    "trust earned in the heat of battle",
+    "an oath sworn between guildmates",
+    "missing a comrade who rides apart from the rest",
+    "a gathering you hope to share when the fighting's done",
+    "thanks for a warning that saved your skin",
+    "the worth of standing shoulder to shoulder",
+    # --- daily life on the road ---
+    "a hearty meal you can't stop thinking about",
+    "the best tavern you ever set foot in",
+    "a drink shared around a campfire",
+    "good-natured grumbling about sore feet",
+    "the comfort of a warm fire after a cold march",
+    "a tune stuck in your head since morning",
+    "the simple luxury of dry boots",
+    "a long road with no end in sight",
+    # --- humor & light banter ---
+    "teasing a guildmate about an old blunder",
+    "a tall tale you swear is true",
+    "boasting (perhaps too much) about a past victory",
+    "a ridiculous wager between friends",
+    "an argument over the best ale in the land",
+    "a cooking mishap around the campfire",
+    # --- mood & reflection ---
+    "the quiet before a coming storm",
+    "homesickness creeping in at dusk",
+    "gratitude for simply seeing another dawn",
+    "doubts that visit in the dark hours",
+    "the strange peace found in solitude",
+    "weariness that sleep won't cure",
+    "hope found in a small kindness",
+    # --- lore & places ---
+    "ruins that hint at a forgotten people",
+    "a shrine or grave you passed on the road",
+    "stories the elders told when you were young",
+    "a battlefield long since grown over with grass",
+    "spirits said to linger in this place",
+    "a festival or holy day from your youth",
+    # --- the calling & the blade ---
+    "the weight of the weapon you carry",
+    "scars that each tell their own story",
+    "an enemy you respect despite everything",
+    "the thin line between duty and vengeance",
+    "the first time you faced true danger",
+    "the discipline your training demanded",
+    # --- faction & war ---
+    "rumors of the enemy massing nearby",
+    "the price the war has taken from your people",
+    "an uneasy truce you doubt will hold",
+    "tales of heroes who turned the tide",
+    # --- nature, beasts & weather ---
+    "tracks of a great beast crossing your trail",
+    "birdsong, or its uneasy absence, at dawn",
+    "a sudden storm that caught you unready",
+    "the first frost, or the first thaw",
+    "a loyal beast that once saved your life",
+    "the night sky far from any town",
+    # --- craft & trade ---
+    "the satisfaction of mending your own gear by hand",
+    "the smell of a forge or a brewing pot",
+    "a trade secret passed down in your family",
+    "pride in something you made with your hands",
+    # --- omens & the uncanny ---
+    "a dream that felt like a warning",
+    "a stranger's cryptic words on the road",
+    "lights or sounds with no earthly source",
+    "a curse you half-believe in",
+    # --- legacy & loss ---
+    "what you'd want remembered after you're gone",
+    "a debt of honor still unpaid",
+    "the names of those you've lost",
 ]

--- a/tools/chatter_constants.py
+++ b/tools/chatter_constants.py
@@ -3520,7 +3520,7 @@ GUILD_CHAT_TOPICS = [
 GUILD_CHAT_TOPICS_RP = [
     "the dangers of the road you're traveling",
     "a rumor overheard in the last town",
-    "your faith, code, or philosophy",
+    "the code or philosophy you live by",
     "honoring a fallen comrade",
     "the beauty or menace of the land around you",
     "a personal vow or quest you carry",
@@ -3531,7 +3531,7 @@ GUILD_CHAT_TOPICS_RP = [
     "an omen or strange sight on your path",
     "gratitude for a guildmate's aid",
     "the toll of endless fighting",
-    "a prayer or blessing for the guild",
+    "a wish of good fortune for the guild",
     "longing for a quieter life",
     "pride in your craft or lineage",
     "a warning about a place best avoided",

--- a/tools/chatter_guild.py
+++ b/tools/chatter_guild.py
@@ -99,6 +99,23 @@ def _query_speaker(db, bot_guid: int) -> Dict[str, object]:
         return {}
 
 
+import random
+from chatter_constants import GUILD_CHAT_TOPICS, GUILD_CHAT_TOPICS_RP
+
+
+def _guild_length_hint():
+    """Roadmap #5: vary message length so guild lines do not all read the
+    same length. Favors short/medium, occasionally a full sentence."""
+    return random.choices(
+        ["very short (under 50 characters)",
+         "short (50-90 characters)",
+         "short (50-90 characters)",
+         "medium (90-150 characters)",
+         "a full sentence (150-200 characters)"],
+        weights=[20, 30, 30, 15, 5],
+    )[0]
+
+
 def _build_guild_prompt(
     speaker_name: str,
     speaker: Dict,
@@ -148,6 +165,11 @@ def _build_guild_prompt(
                 "it — this is guild chat, so guildmates "
                 "elsewhere will read it."
             )
+    topic = random.choice(GUILD_CHAT_TOPICS_RP)
+    lines.append(
+        "Topic idea (optional - only use it if it fits "
+        f"naturally, do not force it): {topic}."
+    )
     lines.append(
         "Stay fully in character — you ARE this person "
         "in Azeroth. No fourth-wall breaks and no "
@@ -160,7 +182,7 @@ def _build_guild_prompt(
         "Write ONE short, casual line for guild "
         "chat, in character, the way a real person "
         "playing WoW would chat with their guild. "
-        "Length: keep it under 200 characters. No "
+        f"Length: {_guild_length_hint()}. HARD LIMIT: never exceed 200 characters. No "
         "quotation marks, no name prefix, no "
         "roleplay asterisks."
     )

--- a/tools/chatter_guild.py
+++ b/tools/chatter_guild.py
@@ -16,6 +16,7 @@ from chatter_db import insert_chat_message
 from chatter_llm import call_llm
 from chatter_shared import (
     append_json_instruction,
+    get_chatter_mode,
     get_class_name,
     get_gender_label,
     get_race_name,
@@ -101,53 +102,15 @@ def _query_speaker(db, bot_guid: int) -> Dict[str, object]:
 
 
 from chatter_constants import GUILD_CHAT_TOPICS_RP
+from chatter_general import _pick_length_hint
 
 
-# Roadmap #5 / review #1: deterministic length buckets. The model is unreliable
-# at obeying character limits (observed compliance was poor), so we pick a bucket,
-# hint it in the prompt, AND hard-cap the parsed output to the bucket's max after
-# the fact. Hint + enforcement are kept in lockstep here.
-GUILD_LENGTH_BUCKETS = [
-    # (key, prompt hint, hard max chars, weight)
-    ("very_short", "very short — just a few words", 48, 20),
-    ("short", "short — one brief line", 90, 40),
-    ("medium", "medium — a single sentence", 145, 30),
-    ("long", "a full sentence", 190, 10),
-]
-
-
-def _pick_guild_length():
-    """Return (key, hint, max_chars) for one weighted length bucket."""
-    bucket = random.choices(
-        GUILD_LENGTH_BUCKETS,
-        weights=[b[3] for b in GUILD_LENGTH_BUCKETS],
-    )[0]
-    return bucket[0], bucket[1], bucket[2]
-
-
-def _truncate_to(message: str, max_chars: int) -> str:
-    """Hard-cap a message to max_chars, avoiding a mid-word split WHEN POSSIBLE:
-    prefers a sentence boundary, then a word boundary, and only falls back to a
-    hard cut for unbroken text (e.g. a single very long token). Never emits an
-    ellipsis so the result stays strictly within the bucket's char budget."""
-    message = message.strip()
-    if len(message) <= max_chars:
-        return message
-    window = message[:max_chars]
-    # 1) end on sentence punctuation if one sits in the back half of the window
-    best = -1
-    for p in ('. ', '! ', '? ', '; '):
-        idx = window.rfind(p)
-        if idx > best:
-            best = idx
-    if best >= max_chars * 0.5:
-        return window[:best + 1].strip()
-    # 2) otherwise cut on the last word boundary
-    idx = window.rfind(' ')
-    if idx >= max_chars * 0.4:
-        return window[:idx].rstrip(' ,;:-').strip()
-    # 3) last resort: hard cut
-    return window.rstrip()
+# Length control mirrors the General channel, which works well: we do NOT
+# hard-cap or chop the model's output after the fact (the old per-bucket
+# _truncate_to butchered lines mid-sentence). Instead we reuse General's
+# _pick_length_hint(mode) — a char-range target plus a single generous
+# "HARD LIMIT: Never exceed 150 characters total" stated in the prompt —
+# and deliver the model's full, coherent sentence intact.
 
 
 # Review #4: never insult your own faction. Derive Alliance/Horde from race so
@@ -258,9 +221,10 @@ def _build_guild_prompt(
     guildmates: str,
     config: Optional[Dict] = None,
     zone_id: int = 0,
-    length_hint: str = "short — one brief line",
+    length_hint: str = "",
     topic: str = "",
     faction: str = "",
+    name_zone: bool = False,
 ) -> str:
     lines = [_guild_identity(speaker_name, speaker)]
     lines.append(
@@ -301,22 +265,45 @@ def _build_guild_prompt(
     if zone_id:
         zone = get_zone_name(zone_id)
         if zone:
-            # Review #5: prefer the curated, lore-accurate zone flavor as
-            # POSITIVE context so the model draws on real local color rather
-            # than inventing NPCs/towns/factions that may not exist there.
+            # Guild chat reaches guildmates scattered across other zones who
+            # cannot see where the speaker stands, so deictic references ("this
+            # swamp", "here") read as nonsense to them. Whether to name the
+            # location is decided by an RNG roll in the handler (name_zone) —
+            # the model cannot be trusted to self-pace it. We deliberately give
+            # NO phrasing examples here: examples make the model echo them into
+            # repetitive patterns.
             flavor = get_zone_flavor(zone_id)
-            if flavor:
+            if name_zone:
+                # Review #5: curated lore flavor as POSITIVE context so the
+                # model draws on real local color rather than inventing it.
+                if flavor:
+                    lines.append(
+                        f"You are currently in {zone}. Local color you may "
+                        f"draw on: {flavor} Use only this for specifics; do "
+                        "NOT invent other local NPCs, towns, factions, or "
+                        "events."
+                    )
+                else:
+                    lines.append(
+                        f"You are currently in {zone}. You may react to the "
+                        "land itself (its weather, danger, mood) but do NOT "
+                        "invent specific local NPCs, towns, or events you "
+                        "cannot be sure exist."
+                    )
                 lines.append(
-                    f"You are currently in {zone}. Local color you may "
-                    f"draw on: {flavor} Use only this for specifics; do "
-                    "NOT invent other local NPCs, towns, factions, or events."
+                    f"Most of your guildmates are far away in other lands and "
+                    f"cannot see where you are, so name {zone} somewhere in "
+                    "your line, woven in naturally, so they know where you "
+                    "speak from."
                 )
             else:
+                # RNG said no: forbid referencing the location at all this
+                # round so we never get a deictic line with no place name.
                 lines.append(
-                    f"You are currently in {zone}. You may react to "
-                    "the land itself (its weather, danger, mood) but "
-                    "do NOT invent specific local NPCs, towns, or "
-                    "events you cannot be sure exist."
+                    "Most of your guildmates are far away and cannot see "
+                    "where you are. Do NOT name or describe your current "
+                    "location or immediate surroundings this time — speak of "
+                    "other matters instead."
                 )
     if not topic:
         topic = random.choice(GUILD_CHAT_TOPICS_RP)
@@ -344,11 +331,14 @@ def _build_guild_prompt(
     )
     lines.append(
         "Write ONE casual, in-character line for guild chat, the "
-        "way this person would actually speak. "
-        f"Length: {length_hint}. No quotation marks, no name "
-        "prefix, no roleplay asterisks, no emotes or actions — "
-        "just the spoken line."
+        "way this person would actually speak. No quotation marks, "
+        "no name prefix, no roleplay asterisks, no emotes or "
+        "actions — just the spoken line."
     )
+    # Length control mirrors the General channel: a char-range target plus a
+    # single generous HARD LIMIT, stated in the prompt. No post-parse cut.
+    if length_hint:
+        lines.append(length_hint)
 
     # Review #2: message-only JSON. Do not request emote/action
     # fields so they cannot leak into the displayed line.
@@ -391,15 +381,26 @@ def process_guild_idle_chatter_event(
         return False
 
     zone_id = int(extra.get('zone_id', 0) or 0)
-    length_key, length_hint, length_max = _pick_guild_length()
+    # Length control mirrors the General channel (which works well): reuse
+    # its _pick_length_hint(mode) and let the prompt enforce length. No
+    # post-parse truncation — the model's full sentence is delivered intact.
+    length_hint = _pick_length_hint(get_chatter_mode(config))
     topic = random.choice(GUILD_CHAT_TOPICS_RP)
     # PR #30 follow-up #1: prefer the C++ GetTeamId() faction (extra_data
     # "team"); fall back to the Python race-derived faction.
     faction = extra.get('team') or _speaker_faction(speaker)
+    # Zone-naming is decided here by RNG, not left to the model (it cannot
+    # self-pace "occasionally"). On a hit the prompt asks the bot to name its
+    # zone so scattered guildmates have context; on a miss it forbids any
+    # location reference. Tunable via LLMChatter.GuildChatter.ZoneNameChance.
+    zone_name_chance = int(config.get(
+        'LLMChatter.GuildChatter.ZoneNameChance', 10))
+    name_zone = random.randint(1, 100) <= zone_name_chance
     prompt = _build_guild_prompt(
         speaker_name, speaker, guild_name,
         guildmates, config, zone_id=zone_id,
         length_hint=length_hint, topic=topic, faction=faction,
+        name_zone=name_zone,
     )
 
     max_tokens = int(config.get(
@@ -409,9 +410,10 @@ def process_guild_idle_chatter_event(
     # metadata so they land as top-level fields in llm_requests.jsonl
     # (the monitoring pass can read them without parsing prompt text).
     metadata = {
-        "guild_length_bucket": length_key,
-        "guild_length_max_chars": length_max,
+        "guild_length_hint": length_hint.split("\n", 1)[0]
+        .replace("Length: ", "").strip(),
         "guild_topic": topic,
+        "guild_named_zone": name_zone,
         "guild_faction": faction,
         "guild_zone_id": zone_id,
         "guild_zone_name": get_zone_name(zone_id) or "",
@@ -441,14 +443,13 @@ def process_guild_idle_chatter_event(
     if not message:
         _mark_event(db, event_id, 'skipped')
         return False
-    # Review #1: deterministic hard cap to the chosen length bucket
-    # (the model is unreliable at obeying the in-prompt limit).
-    message = _truncate_to(message, length_max)
-    # Review #7: surface the generation controls for later verification.
+    # No post-parse truncation (mirrors the General channel): the prompt's
+    # length hint + HARD LIMIT control length, and the full coherent line is
+    # delivered as-is so messages are never cut mid-sentence.
     logger.info(
-        "guild_idle_chatter speaker=%s bucket=%s max_chars=%d "
+        "guild_idle_chatter speaker=%s "
         "faction=%s zone_id=%d topic=%r out_len=%d",
-        speaker_name, length_key, length_max,
+        speaker_name,
         faction or "-", zone_id, topic, len(message),
     )
 

--- a/tools/chatter_guild.py
+++ b/tools/chatter_guild.py
@@ -100,8 +100,7 @@ def _query_speaker(db, bot_guid: int) -> Dict[str, object]:
         return {}
 
 
-import random
-from chatter_constants import GUILD_CHAT_TOPICS, GUILD_CHAT_TOPICS_RP
+from chatter_constants import GUILD_CHAT_TOPICS_RP
 
 
 # Roadmap #5 / review #1: deterministic length buckets. The model is unreliable
@@ -261,6 +260,7 @@ def _build_guild_prompt(
     zone_id: int = 0,
     length_hint: str = "short — one brief line",
     topic: str = "",
+    faction: str = "",
 ) -> str:
     lines = [_guild_identity(speaker_name, speaker)]
     lines.append(
@@ -286,7 +286,10 @@ def _build_guild_prompt(
         )
 
     # Review #4: faction awareness — never insult your own side.
-    faction = _speaker_faction(speaker)
+    # PR #30 follow-up #1: prefer the authoritative C++ GetTeamId() value
+    # (extra_data "team"); fall back to the Python race-derived faction.
+    if not faction:
+        faction = _speaker_faction(speaker)
     if faction:
         lines.append(
             f"You fight for the {faction}. Never insult or mock "
@@ -353,6 +356,7 @@ def _build_guild_prompt(
         "\n".join(lines) + "\n",
         allow_action=False,
         skip_emote=True,
+        message_only=True,
     )
 
 
@@ -389,20 +393,36 @@ def process_guild_idle_chatter_event(
     zone_id = int(extra.get('zone_id', 0) or 0)
     length_key, length_hint, length_max = _pick_guild_length()
     topic = random.choice(GUILD_CHAT_TOPICS_RP)
+    # PR #30 follow-up #1: prefer the C++ GetTeamId() faction (extra_data
+    # "team"); fall back to the Python race-derived faction.
+    faction = extra.get('team') or _speaker_faction(speaker)
     prompt = _build_guild_prompt(
         speaker_name, speaker, guild_name,
         guildmates, config, zone_id=zone_id,
-        length_hint=length_hint, topic=topic,
+        length_hint=length_hint, topic=topic, faction=faction,
     )
 
     max_tokens = int(config.get(
         'LLMChatter.GuildChatter.MaxTokens', 200
     ))
+    # PR #30 follow-up #2: pass the generation controls as structured
+    # metadata so they land as top-level fields in llm_requests.jsonl
+    # (the monitoring pass can read them without parsing prompt text).
+    metadata = {
+        "guild_length_bucket": length_key,
+        "guild_length_max_chars": length_max,
+        "guild_topic": topic,
+        "guild_faction": faction,
+        "guild_zone_id": zone_id,
+        "guild_zone_name": get_zone_name(zone_id) or "",
+        "guild_zone_flavor": get_zone_flavor(zone_id) or "",
+    }
     response = call_llm(
         client, prompt, config,
         max_tokens_override=max_tokens,
         context=f"guild:{speaker_name}",
         label='guild_idle_chatter',
+        metadata=metadata,
     )
     if not response:
         _mark_event(db, event_id, 'skipped')
@@ -429,7 +449,7 @@ def process_guild_idle_chatter_event(
         "guild_idle_chatter speaker=%s bucket=%s max_chars=%d "
         "faction=%s zone_id=%d topic=%r out_len=%d",
         speaker_name, length_key, length_max,
-        _speaker_faction(speaker) or "-", zone_id, topic, len(message),
+        faction or "-", zone_id, topic, len(message),
     )
 
     insert_chat_message(

--- a/tools/chatter_guild.py
+++ b/tools/chatter_guild.py
@@ -9,17 +9,18 @@ raid idle-morale and proximity handlers.
 
 import logging
 import random
+import re
 from typing import Dict, Optional
 
 from chatter_db import insert_chat_message
 from chatter_llm import call_llm
 from chatter_shared import (
     append_json_instruction,
-    build_bot_identity_with_level,
     get_class_name,
     get_gender_label,
     get_race_name,
     get_zone_name,
+    get_zone_flavor,
     parse_extra_data,
 )
 from chatter_text import (
@@ -103,17 +104,152 @@ import random
 from chatter_constants import GUILD_CHAT_TOPICS, GUILD_CHAT_TOPICS_RP
 
 
-def _guild_length_hint():
-    """Roadmap #5: vary message length so guild lines do not all read the
-    same length. Favors short/medium, occasionally a full sentence."""
-    return random.choices(
-        ["very short (under 50 characters)",
-         "short (50-90 characters)",
-         "short (50-90 characters)",
-         "medium (90-150 characters)",
-         "a full sentence (150-200 characters)"],
-        weights=[20, 30, 30, 15, 5],
+# Roadmap #5 / review #1: deterministic length buckets. The model is unreliable
+# at obeying character limits (observed compliance was poor), so we pick a bucket,
+# hint it in the prompt, AND hard-cap the parsed output to the bucket's max after
+# the fact. Hint + enforcement are kept in lockstep here.
+GUILD_LENGTH_BUCKETS = [
+    # (key, prompt hint, hard max chars, weight)
+    ("very_short", "very short — just a few words", 48, 20),
+    ("short", "short — one brief line", 90, 40),
+    ("medium", "medium — a single sentence", 145, 30),
+    ("long", "a full sentence", 190, 10),
+]
+
+
+def _pick_guild_length():
+    """Return (key, hint, max_chars) for one weighted length bucket."""
+    bucket = random.choices(
+        GUILD_LENGTH_BUCKETS,
+        weights=[b[3] for b in GUILD_LENGTH_BUCKETS],
     )[0]
+    return bucket[0], bucket[1], bucket[2]
+
+
+def _truncate_to(message: str, max_chars: int) -> str:
+    """Hard-cap a message to max_chars, avoiding a mid-word split WHEN POSSIBLE:
+    prefers a sentence boundary, then a word boundary, and only falls back to a
+    hard cut for unbroken text (e.g. a single very long token). Never emits an
+    ellipsis so the result stays strictly within the bucket's char budget."""
+    message = message.strip()
+    if len(message) <= max_chars:
+        return message
+    window = message[:max_chars]
+    # 1) end on sentence punctuation if one sits in the back half of the window
+    best = -1
+    for p in ('. ', '! ', '? ', '; '):
+        idx = window.rfind(p)
+        if idx > best:
+            best = idx
+    if best >= max_chars * 0.5:
+        return window[:best + 1].strip()
+    # 2) otherwise cut on the last word boundary
+    idx = window.rfind(' ')
+    if idx >= max_chars * 0.4:
+        return window[:idx].rstrip(' ,;:-').strip()
+    # 3) last resort: hard cut
+    return window.rstrip()
+
+
+# Review #4: never insult your own faction. Derive Alliance/Horde from race so
+# the prompt can pass the speaker's side and forbid self-faction jabs.
+_ALLIANCE_RACES = {"Human", "Dwarf", "Night Elf", "Gnome", "Draenei"}
+_HORDE_RACES = {"Orc", "Undead", "Scourge", "Tauren", "Troll", "Blood Elf"}
+
+
+def _faction_of(race_name: str) -> str:
+    if race_name in _ALLIANCE_RACES:
+        return "Alliance"
+    if race_name in _HORDE_RACES:
+        return "Horde"
+    return ""
+
+
+def _speaker_faction(speaker: Dict) -> str:
+    """Resolve the speaker's faction from its race (name or id), defensively."""
+    race = speaker.get('race')
+    candidates = []
+    if isinstance(race, str):
+        candidates.append(race)
+    try:
+        candidates.append(get_race_name(race))
+    except Exception:
+        pass
+    for c in candidates:
+        fac = _faction_of((c or '').strip())
+        if fac:
+            return fac
+    return ""
+
+
+# Review #2 (strict): guild lines are SPOKEN text only. The message-only schema +
+# cleanup_message() handle the common cases, but the model can still embed marked
+# RP artifacts INSIDE the message field. Deterministically strip them so we never
+# rely on prompt pressure alone: /me|/e|/emote prefixes, *narrator* fragments
+# (leading/trailing/inline), <emote>..</emote>-style tags, and stray backticks.
+def _strip_rp_artifacts(message: str) -> str:
+    if not message:
+        return ""
+    s = message
+    # slash-emote command prefixes (/me, /e, /emote)
+    s = re.sub(r'^\s*/(?:me|e|emote)\b[:,]?\s*', '', s, flags=re.IGNORECASE)
+    # angle-bracket emote/action tags and any stray short html-ish tag
+    s = re.sub(r'</?\s*(?:emote|action|i|em|rp|me)\s*>', ' ',
+               s, flags=re.IGNORECASE)
+    s = re.sub(r'<[^<>]{0,40}>', ' ', s)
+    # *...* narrator fragments anywhere, then any leftover lone asterisks
+    s = re.sub(r'\*[^*]{1,80}\*', ' ', s)
+    s = s.replace('*', '')
+    # explicit "emote:"/"action:" leads
+    s = re.sub(r'^\s*(?:emote|action)\s*:\s*', '', s, flags=re.IGNORECASE)
+    # stray fences/backticks
+    s = s.replace('```', '').replace('`', '')
+    # collapse whitespace opened up by removals
+    s = re.sub(r'\s{2,}', ' ', s).strip(' ,;:-\t')
+    return s.strip()
+
+
+# Review #6: never put "level N" in the guild prompt — handing the model the exact
+# forbidden mechanic ("levels") undermines the jargon ban. Translate level into
+# non-mechanical flavor instead.
+def _level_flavor(level) -> str:
+    try:
+        lvl = int(level)
+    except (TypeError, ValueError):
+        return ""
+    if lvl <= 0:
+        return ""
+    if lvl < 20:
+        return "a young adventurer"
+    if lvl < 60:
+        return "a seasoned traveler"
+    if lvl < 80:
+        return "a hardened campaigner"
+    return "a battle-hardened veteran"
+
+
+def _resolve_name(name_fn, val, default: str) -> str:
+    """Resolve a race/class to a display name whether it's already a name or an id."""
+    if isinstance(val, str) and val and not val.isdigit():
+        return val
+    try:
+        r = name_fn(val)
+        if r:
+            return r
+    except Exception:
+        pass
+    return default
+
+
+def _guild_identity(speaker_name: str, speaker: Dict) -> str:
+    """Non-mechanical identity line for guild chat (no 'level N')."""
+    race = _resolve_name(get_race_name, speaker.get('race'), 'wanderer')
+    klass = _resolve_name(get_class_name, speaker.get('class'), 'adventurer')
+    flavor = _level_flavor(speaker.get('level'))
+    base = f"You are {speaker_name}, a {race} {klass} of Azeroth"
+    if flavor:
+        base += f" — {flavor}"
+    return base + "."
 
 
 def _build_guild_prompt(
@@ -123,16 +259,10 @@ def _build_guild_prompt(
     guildmates: str,
     config: Optional[Dict] = None,
     zone_id: int = 0,
+    length_hint: str = "short — one brief line",
+    topic: str = "",
 ) -> str:
-    identity = build_bot_identity_with_level(
-        speaker_name,
-        speaker.get('race', 'Unknown'),
-        speaker.get('class', 'Adventurer'),
-        speaker.get('level', 1),
-        gender=speaker.get('gender', ''),
-    )
-
-    lines = [identity]
+    lines = [_guild_identity(speaker_name, speaker)]
     lines.append(
         f"You are a member of the guild "
         f"\"{guild_name}\"."
@@ -155,40 +285,74 @@ def _build_guild_prompt(
             f"{guildmates}."
         )
 
+    # Review #4: faction awareness — never insult your own side.
+    faction = _speaker_faction(speaker)
+    if faction:
+        lines.append(
+            f"You fight for the {faction}. Never insult or mock "
+            f"the {faction} — they are your own people. If you "
+            "speak of rivalry, it is only toward the opposing "
+            "faction."
+        )
+
     if zone_id:
         zone = get_zone_name(zone_id)
         if zone:
-            lines.append(
-                f"You are currently in {zone}. You may "
-                "naturally mention what you are doing there "
-                "(questing, leveling, traveling) or react to "
-                "it — this is guild chat, so guildmates "
-                "elsewhere will read it."
-            )
-    topic = random.choice(GUILD_CHAT_TOPICS_RP)
+            # Review #5: prefer the curated, lore-accurate zone flavor as
+            # POSITIVE context so the model draws on real local color rather
+            # than inventing NPCs/towns/factions that may not exist there.
+            flavor = get_zone_flavor(zone_id)
+            if flavor:
+                lines.append(
+                    f"You are currently in {zone}. Local color you may "
+                    f"draw on: {flavor} Use only this for specifics; do "
+                    "NOT invent other local NPCs, towns, factions, or events."
+                )
+            else:
+                lines.append(
+                    f"You are currently in {zone}. You may react to "
+                    "the land itself (its weather, danger, mood) but "
+                    "do NOT invent specific local NPCs, towns, or "
+                    "events you cannot be sure exist."
+                )
+    if not topic:
+        topic = random.choice(GUILD_CHAT_TOPICS_RP)
     lines.append(
         "Topic idea (optional - only use it if it fits "
         f"naturally, do not force it): {topic}."
     )
+    # Review #3: keep content within the speaker's OWN class/race idiom — the
+    # model otherwise borrows another class's fantasy (a warlock invoking
+    # ancestors, a death knight using fel, etc.).
     lines.append(
-        "Stay fully in character — you ARE this person "
-        "in Azeroth. No fourth-wall breaks and no "
-        "out-of-character or game-mechanic talk (no DPS "
-        "meters, rotations, addons, or references to the "
-        "player behind the screen). Draw on your race, "
-        "class and surroundings."
+        "Speak only in the idiom that fits your own race and class. Do NOT "
+        "borrow another class's powers or imagery — do not invoke spirits, "
+        "ancestors, the Light, the elements, nature, or fel unless that "
+        "genuinely belongs to who you are."
     )
     lines.append(
-        "Write ONE short, casual line for guild "
-        "chat, in character, the way a real person "
-        "playing WoW would chat with their guild. "
-        f"Length: {_guild_length_hint()}. HARD LIMIT: never exceed 200 characters. No "
-        "quotation marks, no name prefix, no "
-        "roleplay asterisks."
+        "Stay fully in character — you ARE this person in Azeroth, "
+        "speaking to your guild. No fourth-wall breaks and no "
+        "out-of-character or game-mechanic talk. NEVER use words "
+        "like grinding, pulls, DPS, specs, talents, loot, mobs, "
+        "XP, levels, rotations, addons, or any reference to the "
+        "player behind the screen. Speak of foes, the road, your "
+        "craft and your calling — not game systems."
+    )
+    lines.append(
+        "Write ONE casual, in-character line for guild chat, the "
+        "way this person would actually speak. "
+        f"Length: {length_hint}. No quotation marks, no name "
+        "prefix, no roleplay asterisks, no emotes or actions — "
+        "just the spoken line."
     )
 
+    # Review #2: message-only JSON. Do not request emote/action
+    # fields so they cannot leak into the displayed line.
     return append_json_instruction(
-        "\n".join(lines) + "\n"
+        "\n".join(lines) + "\n",
+        allow_action=False,
+        skip_emote=True,
     )
 
 
@@ -223,9 +387,12 @@ def process_guild_idle_chatter_event(
         return False
 
     zone_id = int(extra.get('zone_id', 0) or 0)
+    length_key, length_hint, length_max = _pick_guild_length()
+    topic = random.choice(GUILD_CHAT_TOPICS_RP)
     prompt = _build_guild_prompt(
         speaker_name, speaker, guild_name,
         guildmates, config, zone_id=zone_id,
+        length_hint=length_hint, topic=topic,
     )
 
     max_tokens = int(config.get(
@@ -245,14 +412,25 @@ def process_guild_idle_chatter_event(
     message = strip_speaker_prefix(
         parsed.get('message', ''), speaker_name
     )
-    message = cleanup_message(
-        message, action=parsed.get('action')
-    )
+    # Review #2: message-only — drop any emote/action the model may have
+    # leaked; never prepend a narrator action to guild lines.
+    message = cleanup_message(message)
+    # Review #2 (strict): deterministically strip marked RP artifacts that can
+    # still ride inside the message field (/me, *action*, <emote>, fences).
+    message = _strip_rp_artifacts(message)
     if not message:
         _mark_event(db, event_id, 'skipped')
         return False
-    if len(message) > 255:
-        message = message[:252] + "..."
+    # Review #1: deterministic hard cap to the chosen length bucket
+    # (the model is unreliable at obeying the in-prompt limit).
+    message = _truncate_to(message, length_max)
+    # Review #7: surface the generation controls for later verification.
+    logger.info(
+        "guild_idle_chatter speaker=%s bucket=%s max_chars=%d "
+        "faction=%s zone_id=%d topic=%r out_len=%d",
+        speaker_name, length_key, length_max,
+        _speaker_faction(speaker) or "-", zone_id, topic, len(message),
+    )
 
     insert_chat_message(
         db,

--- a/tools/chatter_shared.py
+++ b/tools/chatter_shared.py
@@ -1387,6 +1387,7 @@ def append_json_instruction(
     prompt: str, allow_action: bool = True,
     skip_emote: bool = False,
     skip_action_rng: bool = False,
+    message_only: bool = False,
 ) -> str:
     """Append structured JSON response instruction
     to a prompt.
@@ -1399,7 +1400,27 @@ def append_json_instruction(
     skip_action_rng=True bypasses the pre-call RNG
     so the caller can apply post-parse stripping
     instead (used by General conversation paths).
+    message_only=True emits a strict {"message": "..."} schema with no
+    emote/action fields at all (e.g. guild chat, which is spoken text only).
     """
+    if message_only:
+        lang_rule = get_language_rule()
+        if lang_rule:
+            prompt = prompt + lang_rule
+        block = (
+            "\n\nRESPONSE FORMAT: You MUST respond with "
+            "ONLY valid JSON. No other text.\n"
+            "{\n"
+            '  "message": "your spoken words here"\n'
+            "}\n"
+            "Rules: double quotes only, no trailing "
+            "commas, no code fences, no markdown.\n"
+            "CRITICAL: Follow the Length instruction "
+            "in the prompt exactly — never exceed the "
+            "stated character limit."
+            f"{lang_rule}"
+        )
+        return PromptParts(prompt, block)
     # Apply ActionChance RNG: allow_action=True means
     # "eligible for action" — the RNG decides.
     # allow_action=False means "never include action"


### PR DESCRIPTION
Follow-up to #28, implementing two items from your post-merge guild-chat roadmap:

**#2 — Random subject pool.** Adds `GUILD_CHAT_TOPICS` (everyday/leveling-realistic) and `GUILD_CHAT_TOPICS_RP` (pure in-character) pools to `chatter_constants.py`, mirroring the existing `AMBIENT_CHAT_TOPICS` pattern. `_build_guild_prompt` now injects a random topic as an **optional** nudge ("only use it if it fits naturally, don't force it") so guild idle chatter varies its subject instead of looping the same themes. Uses the RP pool to match guild chat's fully-in-character stance.

**#5 — Length variation.** Replaces the fixed `Length: keep it under 200 characters` hint with a weighted random length bucket (`_guild_length_hint()`: very-short → full-sentence, favoring short/medium), so lines vary in length like the other chat types do via `LENGTH_HINTS`. Hard 200-char cap retained.

Additive and config-free — no new keys, no behavior change when topics happen not to fit (the model is told it's optional). `py_compile` green on both files.

Remaining roadmap items (multi-bot conversations, login greetings, event/weather comments) will follow as separate PRs.