### PR TITLE
Add Arabic routing and DeepSeek thinking controls

### DIFF
--- a/conf/mod_llm_chatter.conf.dist
+++ b/conf/mod_llm_chatter.conf.dist
@@ -348,6 +348,14 @@ LLMChatter.OpenRouter.ApiKey = sk-or-v1-xxxxx
 LLMChatter.OpenRouter.BaseUrl = https://openrouter.ai/api/v1
 
 #
+#   LLMChatter.OpenRouter.Thinking
+#       Optional OpenAI-compatible thinking control.
+#       Values: enabled, disabled, or empty.
+#       Leave empty for normal OpenRouter behavior.
+#
+LLMChatter.OpenRouter.Thinking =
+
+#
 #   LLMChatter.OpenRouter.HttpReferer
 #       Optional site URL for OpenRouter attribution/rankings.
 #       Leave empty if you do not want to send this header.

--- a/conf/mod_llm_chatter.conf.dist
+++ b/conf/mod_llm_chatter.conf.dist
@@ -468,6 +468,7 @@ LLMChatter.ChatterMode = roleplay
 #           ES      - Spanish
 #           PT      - Portuguese
 #           RU      - Russian
+#           AR      - Arabic (preserves already-localized server names)
 #       Adding a new language:
 #           Edit modules/mod-llm-chatter/tools/chatter_shared.py
 #           and add an entry to the _LANGUAGE_LABELS dict

--- a/tools/chatter_healthcheck.py
+++ b/tools/chatter_healthcheck.py
@@ -493,16 +493,25 @@ def _probe_anthropic(config, model):
     return resp.content[0].text.strip()
 
 
-def _probe_openai_compatible(client, model):
+def _probe_openai_compatible(client, model, config, provider):
     """Make a minimal OpenAI-compatible call; text or raises."""
-    resp = client.chat.completions.create(
-        model=model,
-        max_tokens=5,
-        messages=[{
+    kwargs = {
+        'model': model,
+        'max_tokens': 5,
+        'messages': [{
             'role': 'user',
             'content': 'Reply with the single word: OK',
         }],
-    )
+    }
+    if provider == 'openrouter':
+        thinking = str(config.get(
+            'LLMChatter.OpenRouter.Thinking', ''
+        )).strip().lower()
+        if thinking in ('enabled', 'disabled'):
+            kwargs['extra_body'] = {
+                'thinking': {'type': thinking}
+            }
+    resp = client.chat.completions.create(**kwargs)
     content = resp.choices[0].message.content
     if isinstance(content, str):
         return content.strip()
@@ -574,7 +583,9 @@ def _check_llm_probe(config):
             client = _build_openai_compatible_client(
                 config, provider
             )
-            text = _probe_openai_compatible(client, model)
+            text = _probe_openai_compatible(
+                client, model, config, provider
+            )
 
         if text:
             return _result(

--- a/tools/chatter_llm.py
+++ b/tools/chatter_llm.py
@@ -122,6 +122,24 @@ def _apply_google_options(kwargs, config):
         kwargs['reasoning_effort'] = effort
 
 
+def _apply_openrouter_options(kwargs, config):
+    """Attach optional OpenAI-compatible thinking controls."""
+    thinking = str(config.get(
+        'LLMChatter.OpenRouter.Thinking', ''
+    )).strip().lower()
+    if not thinking:
+        return
+    if thinking not in ('enabled', 'disabled'):
+        logger.warning(
+            "Invalid LLMChatter.OpenRouter.Thinking=%r",
+            thinking,
+        )
+        return
+    kwargs['extra_body'] = {
+        'thinking': {'type': thinking}
+    }
+
+
 def _effective_max_tokens(provider, config, max_tokens):
     """Adjust provider-specific output budget."""
     if provider != 'google':
@@ -353,6 +371,8 @@ def call_llm(
             }
             if provider == 'google':
                 _apply_google_options(kwargs, config)
+            elif provider == 'openrouter':
+                _apply_openrouter_options(kwargs, config)
             response = client.chat.completions.create(
                 **kwargs
             )
@@ -630,6 +650,8 @@ def quick_llm_analyze(
             }
             if provider == 'google':
                 _apply_google_options(kwargs, config)
+            elif provider == 'openrouter':
+                _apply_openrouter_options(kwargs, config)
             response = (
                 active_client
                 .chat.completions.create(

--- a/tools/chatter_shared.py
+++ b/tools/chatter_shared.py
@@ -1212,6 +1212,7 @@ _language = ""
 
 # Human-readable label used in the prompt rule.
 _LANGUAGE_LABELS = {
+    "AR": "Arabic",
     "DE": "German",
     "ES": "Spanish",
     "FR": "French",
@@ -1294,6 +1295,23 @@ def get_language_rule() -> str:
     """
     if not _language:
         return ""
+    if _language == "Arabic":
+        return (
+            "\nLanguage: Write EVERY field in Arabic — "
+            "the \"message\" field AND the \"action\" "
+            "narrator field must both be fully in Arabic. "
+            "Do not mix languages. Preserve every WoW "
+            "proper noun (zone, subzone, creature, NPC, "
+            "item, spell, quest, and character name) "
+            "exactly as it appears in the supplied server "
+            "context. Names may already be localized into "
+            "Arabic, so never translate them again or force "
+            "them back to English. Any prior chat, memories, "
+            "quoted lines, or examples in this prompt may be "
+            "in another language — treat them only as content "
+            "to react to, never as a guide for which language "
+            "to use. Your entire output must be in Arabic."
+        )
     return (
         f"\nLanguage: Write EVERY field in {_language} — "
         "the \"message\" field AND the \"action\" "

--- a/tools/tests/test_language_prompt_routing.py
+++ b/tools/tests/test_language_prompt_routing.py
@@ -88,6 +88,17 @@ def test_de_language_rule_is_available():
     assert "never as a guide" in rule
 
 
+def test_ar_language_preserves_localized_server_names():
+    chatter_shared.set_language("AR")
+    rule = chatter_shared.get_language_rule()
+    assert "Arabic" in rule
+    assert "exactly as it appears" in rule
+    assert "already be localized into Arabic" in rule
+    assert chatter_shared.get_language_label() == "Arabic"
+    assert chatter_shared.is_supported_language_code("AR")
+    assert "never as a guide" in rule
+
+
 def test_anti_repetition_block_neutralizes_language():
     chatter_shared.set_language("DE")
     block = chatter_shared.build_anti_repetition_context(


### PR DESCRIPTION
## What changed

- preserves the Arabic language-routing compatibility work
- adds optional `LLMChatter.OpenRouter.Thinking` request control
- applies the setting to normal, quick-analysis, and health-check calls

## Why

DeepSeek V4 defaults to thinking mode. Short chatter requests and connectivity probes can spend their response budget on reasoning and return no visible message. Explicit non-thinking support keeps in-game responses fast while leaving ordinary OpenRouter behavior unchanged when the setting is empty.

## Validation

- Python syntax checks passed
- Arabic language-routing suite passed
- thinking-control assertion passed
- live DeepSeek connectivity, database, and required-table health checks passed
