### PR TITLE
pin anthropic version to 0.125.0

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,3 @@
-anthropic
+anthropic==0.125.0
 openai
 mysql-connector-python


### PR DESCRIPTION
Pins a specific anthropic version as stopgap bug fix #50 

Long term fix would be to update code to work with newer API.