### PR TITLE
Fix Playerbot selector command filtering

### DIFF
--- a/src/LLMChatterGroup.cpp
+++ b/src/LLMChatterGroup.cpp
@@ -953,6 +953,88 @@ bool IsLikelyPlayerbotControlCommand(
     if (msg.empty())
         return false;
 
+    // Playerbots @target selector syntax is control traffic,
+    // not conversational content.
+    if (msg[0] == '@')
+    {
+        size_t selectorEnd = msg.find_first_of(" \t");
+        std::string selector =
+            msg.substr(0, selectorEnd);
+
+        static std::unordered_set<std::string>
+            selectorPrefixes = {
+                "@tank", "@dps", "@heal",
+                "@ranged", "@melee",
+                "@rangeddps", "@meleedps",
+                "@dk", "@druid", "@hunter",
+                "@mage", "@paladin", "@priest",
+                "@rogue", "@shaman", "@warlock",
+                "@warrior",
+                "@star", "@circle", "@diamond",
+                "@triangle", "@moon", "@square",
+                "@cross", "@skull",
+                "@hpal", "@ppal", "@rpal",
+                "@disc", "@hpr", "@spr",
+                "@arc", "@frost", "@fire",
+                "@arms", "@fury", "@pwar",
+                "@affl", "@demo", "@dest",
+                "@ele", "@enh", "@rsha",
+                "@bal", "@rdru",
+                "@bmh", "@mmh", "@svh",
+                "@mut", "@comb", "@sub",
+                "@fdk", "@udk"
+            };
+
+        bool knownSelector =
+            selectorPrefixes.find(selector)
+                != selectorPrefixes.end()
+            || selector.rfind("@group", 0) == 0
+            || selector.rfind("@aura", 0) == 0
+            || selector.rfind("@noaura", 0) == 0
+            || selector.rfind("@aggroby", 0) == 0;
+
+        auto isDigits = [](std::string const& value)
+        {
+            if (value.empty())
+                return false;
+
+            return std::all_of(
+                value.begin(), value.end(),
+                [](unsigned char c)
+                {
+                    return std::isdigit(c) != 0;
+                });
+        };
+
+        if (!knownSelector && selector.size() > 1)
+        {
+            std::string levelSelector =
+                selector.substr(1);
+            size_t dash = levelSelector.find('-');
+
+            knownSelector =
+                isDigits(levelSelector)
+                || (dash != std::string::npos
+                    && isDigits(
+                        levelSelector.substr(0, dash))
+                    && isDigits(
+                        levelSelector.substr(dash + 1)));
+        }
+
+        if (knownSelector)
+            return true;
+
+        // Also support @command forms such as @follow while
+        // preserving normal @name conversation.
+        msg.erase(0, 1);
+        size_t commandStart =
+            msg.find_first_not_of(" \t");
+        if (commandStart == std::string::npos)
+            return true;
+        if (commandStart > 0)
+            msg.erase(0, commandStart);
+    }
+
     static std::unordered_set<std::string>
         exactCommands = {
             "u", "c", "e", "s", "b", "r", "t",

--- a/tools/chatter_group.py
+++ b/tools/chatter_group.py
@@ -288,6 +288,59 @@ PLAYERBOT_COMMANDS = {
 }
 
 
+PLAYERBOT_SELECTOR_PREFIXES = {
+    # Role / combat type
+    '@tank', '@dps', '@heal', '@ranged', '@melee',
+    '@rangeddps', '@meleedps',
+
+    # Classes
+    '@dk', '@druid', '@hunter', '@mage', '@paladin',
+    '@priest', '@rogue', '@shaman', '@warlock',
+    '@warrior',
+
+    # Raid target icons
+    '@star', '@circle', '@diamond', '@triangle',
+    '@moon', '@square', '@cross', '@skull',
+
+    # Specs
+    '@hpal', '@ppal', '@rpal',
+    '@disc', '@hpr', '@spr',
+    '@arc', '@frost', '@fire',
+    '@arms', '@fury', '@pwar',
+    '@affl', '@demo', '@dest',
+    '@ele', '@enh', '@rsha',
+    '@bal', '@rdru',
+    '@bmh', '@mmh', '@svh',
+    '@mut', '@comb', '@sub',
+    '@fdk', '@udk',
+}
+
+
+def _is_playerbot_selector(message: str) -> bool:
+    """Return True for Playerbots @target selector syntax."""
+    first_token = message.split(maxsplit=1)[0]
+
+    if first_token in PLAYERBOT_SELECTOR_PREFIXES:
+        return True
+
+    if first_token.startswith(
+        ('@group', '@aura', '@noaura', '@aggroby')
+    ):
+        return True
+
+    # Playerbots also supports @LEVEL and @FROM-TO.
+    level_selector = first_token[1:]
+    if level_selector.isdigit():
+        return True
+
+    if '-' in level_selector:
+        lower, upper = level_selector.split('-', 1)
+        if lower.isdigit() and upper.isdigit():
+            return True
+
+    return False
+
+
 def _is_playerbot_command(message: str) -> bool:
     """Check if a message is a playerbot command.
     Returns True if the full message (stripped,
@@ -298,6 +351,18 @@ def _is_playerbot_command(message: str) -> bool:
     msg = message.strip().lower()
     if not msg:
         return False
+
+    # Playerbots @target selector syntax is control traffic,
+    # not conversational content.
+    if msg.startswith('@'):
+        if _is_playerbot_selector(msg):
+            return True
+
+        # Also support @command forms such as @follow while
+        # preserving normal @name conversation.
+        msg = msg[1:].lstrip()
+        if not msg:
+            return True
 
     # Exact match (e.g. "follow", "stay", "ss")
     if msg in PLAYERBOT_COMMANDS:

--- a/tools/tests/test_playerbot_command_filter.py
+++ b/tools/tests/test_playerbot_command_filter.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import chatter_group
+
+
+def test_playerbot_plain_commands():
+    cases = [
+        "attack",
+        "cast Holy Light",
+        "tank attack",
+    ]
+
+    for message in cases:
+        assert chatter_group._is_playerbot_command(message) is True
+
+
+def test_playerbot_at_commands_and_selectors():
+    cases = [
+        "@follow",
+        "@tank attack",
+        "@dps aoe",
+        "@heal me",
+        "@priest follow",
+        "@star attack",
+        "@hpr follow",
+        "@50 follow",
+        "@45-50 follow",
+        "@group1 follow",
+        "@aura123 follow",
+        "@noaura123 follow",
+        "@aggroby 123 flee",
+    ]
+
+    for message in cases:
+        assert chatter_group._is_playerbot_command(message) is True
+
+
+def test_normal_conversation_is_not_filtered():
+    cases = [
+        "hello everyone",
+        "@Rubberbean hello everyone",
+    ]
+
+    for message in cases:
+        assert chatter_group._is_playerbot_command(message) is False


### PR DESCRIPTION
Fixes #40.

Playerbot control messages that use @ selectors were being treated as normal
conversation by mod-llm-chatter. Examples include:

- @tank attack
- @dps co +passive
- @heal me
- @priest follow
- @group1 follow

This change updates both the C++ pre-enqueue filter and the Python fallback
filter so recognized Playerbot selectors are treated as control traffic while
ordinary @name conversation remains available to Chatter.

It also supports @command forms such as @follow without broadly suppressing
all messages beginning with @.

Validation performed:

- Focused command-filter regression: 18/18 PASS
- Permanent regression tests: 3/3 PASS
- Full clean AzerothCore build: PASS
- worldserver/authserver startup: PASS
- mod-llm-chatter health checks: PASS
- In-game @tank / @dps targeted Playerbot commands continue to work
- Chatter no longer reacts to those Playerbot commands
- Ordinary conversation such as "@Rubberbean hello everyone" still receives
  normal Chatter responses

Tested against current Playerbot master behavior and selector syntax.