### PR TITLE
Fix bridge exiting silently on a non-ASCII (UTF-8) config; give fatal exits real messages

### DIFF
--- a/tools/chatter_shared.py
+++ b/tools/chatter_shared.py
@@ -857,7 +857,11 @@ def parse_config(config_path: str) -> dict:
     """Parse the WoW-style config file."""
     config = {}
     try:
-        with open(config_path, 'r') as f:
+        # utf-8-sig: reads UTF-8, strips a BOM if present, and stays
+        # correct for pure-ASCII files. Without an explicit encoding,
+        # open() defaults to the OS locale (cp1252 on Windows), which
+        # cannot decode common UTF-8 bytes and killed the bridge silently.
+        with open(config_path, 'r', encoding='utf-8-sig') as f:
             for line in f:
                 line = line.strip()
                 if not line or line.startswith('#'):
@@ -866,6 +870,12 @@ def parse_config(config_path: str) -> dict:
                     key, value = line.split('=', 1)
                     config[key.strip()] = value.strip()
     except Exception as e:
+        logger.error(
+            "FATAL: could not read config file %s: %s: %s",
+            config_path,
+            type(e).__name__,
+            e,
+        )
         sys.exit(1)
     return config
 

--- a/tools/llm_chatter_bridge.py
+++ b/tools/llm_chatter_bridge.py
@@ -1301,6 +1301,10 @@ def main():
             'LLMChatter.OpenAI.ApiKey', ''
         )
         if not api_key:
+            logger.error(
+                "FATAL: provider 'openai' selected but "
+                "LLMChatter.OpenAI.ApiKey is empty."
+            )
             sys.exit(1)
         client = openai.OpenAI(api_key=api_key)
     elif provider == 'google':
@@ -1308,6 +1312,10 @@ def main():
             'LLMChatter.Google.ApiKey', ''
         )
         if not api_key:
+            logger.error(
+                "FATAL: provider 'google' selected but "
+                "LLMChatter.Google.ApiKey is empty."
+            )
             sys.exit(1)
         client = openai.OpenAI(
             api_key=api_key,
@@ -1321,6 +1329,10 @@ def main():
             'LLMChatter.OpenRouter.ApiKey', ''
         )
         if not api_key:
+            logger.error(
+                "FATAL: provider 'openrouter' selected but "
+                "LLMChatter.OpenRouter.ApiKey is empty."
+            )
             sys.exit(1)
         headers = {}
         referer = config.get(
@@ -1344,11 +1356,24 @@ def main():
             kwargs['default_headers'] = headers
         client = openai.OpenAI(**kwargs)
     else:
-        # Anthropic (default)
+        # Anthropic is the documented default when Provider is unset.
+        # A *typo* in LLMChatter.Provider also lands here; fail loudly
+        # rather than silently pretending Anthropic was intended.
+        if provider != 'anthropic':
+            logger.error(
+                "FATAL: unknown LLMChatter.Provider '%s'. Valid values: "
+                "anthropic, openai, google, openrouter, ollama.",
+                provider,
+            )
+            sys.exit(1)
         api_key = config.get(
             'LLMChatter.Anthropic.ApiKey', ''
         )
         if not api_key:
+            logger.error(
+                "FATAL: provider 'anthropic' selected but "
+                "LLMChatter.Anthropic.ApiKey is empty."
+            )
             sys.exit(1)
         client = anthropic.Anthropic(api_key=api_key)
 


### PR DESCRIPTION
## Problem

Starting the Python bridge on Windows can exit with status 1 and **completely
empty stdout and stderr** — no traceback, no health report, nothing. It is
indistinguishable from "the process never started", and it cost real debugging
time to trace.

## Root cause

`parse_config()` in `tools/chatter_shared.py` opens the config with no encoding
argument:

```python
with open(config_path, 'r') as f:   # -> locale default (cp1252 on Windows)
    ...
except Exception as e:
    sys.exit(1)                      # swallows everything, prints nothing
```

`open()` defaults to `locale.getpreferredencoding()`, which is **cp1252** on a
default Windows install. A config saved as UTF-8 — which PowerShell's
`Set-Content` / `Out-File -Encoding utf8` produces, BOM included — routinely
contains bytes that are undefined in cp1252 (an em dash `—` is `E2 80 94`; a
right double-quote `”` is `E2 80 9D`, whose `9D` byte is undefined in cp1252).
Decoding raises `UnicodeDecodeError`, which the bare `except` turns into a
silent `sys.exit(1)`. The bound `e` is never used.

The shipped `conf/mod_llm_chatter.conf.dist` is pure ASCII, so this never
surfaces out of the box — only after someone edits the config with a
UTF-8-writing editor or script.

The same silent `sys.exit(1)` pattern also fires when a provider API key is
missing, and the provider dispatch's `else` branch defaults to Anthropic, so a
**typo** in `LLMChatter.Provider` produces the identical silent exit.

## Fix

- `parse_config`: open with `encoding='utf-8-sig'` (reads UTF-8, strips a BOM if
  present, and stays correct for pure-ASCII files), and log the file path and the
  actual exception before exiting.
- The four provider API-key exits (openai / google / openrouter / anthropic) now
  log a real message naming the empty key setting.
- The `else` branch now distinguishes a genuinely unknown/mistyped provider from
  the Anthropic default and logs the unknown value plus the valid set, instead of
  silently pretending Anthropic was intended and then exiting with no message.

No behaviour change for a valid ASCII/UTF-8 config.

## Testing

- `python -m py_compile` on both changed files.
- Parsed the live config through the patched `parse_config` — 267 settings, all
  values unchanged.
- A UTF-8 + BOM config containing an em dash and an arrow (the exact bytes that
  crashed cp1252) now parses cleanly instead of exiting 1.
- An unreadable/nonexistent config now prints `FATAL: could not read config
  file <path>: FileNotFoundError: ...` and exits 1, instead of exiting silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
