### PR TITLE
Protect first_meeting memories from cap eviction (docs say they are immune)

### DIFF
--- a/tools/chatter_memory.py
+++ b/tools/chatter_memory.py
@@ -375,6 +375,13 @@ def _count_active_memories(cursor, bot_guid, player_guid):
 def _evict_one_used(cursor, conn, bot_guid, player_guid):
     """Evict one random used memory.
 
+    first_meeting rows are never evicted: they are documented as immune to
+    prune (they are the templated "Met X in Zone" anchor of the whole
+    remembers-you premise) and they become used=1 the first time the bot
+    greets a returning player, which would otherwise make them eviction-
+    eligible. When only first_meeting rows remain, this deletes nothing and
+    returns False, i.e. it fails closed rather than dropping the anchor.
+
     Returns True if a row was deleted.
     """
     cursor.execute(
@@ -383,6 +390,7 @@ def _evict_one_used(cursor, conn, bot_guid, player_guid):
         "   AND player_guid = %s"
         "   AND active = 1"
         "   AND used = 1"
+        "   AND memory_type != 'first_meeting'"
         " ORDER BY RAND() LIMIT 1",
         (bot_guid, player_guid),
     )


### PR DESCRIPTION
## Problem

`first_meeting` bot memories are documented as immune to pruning, but they are
not protected in code, so a bot can permanently forget that it ever met a
player.

The schema docs (`docs/mod-llm-chatter-documentation.md`) describe the table as:

> `llm_bot_memories` … active=1 persists; **first_meeting immune to prune**

The code does not implement that immunity.

## Root cause

`_evict_one_used()` in `tools/chatter_memory.py` deletes a random `used=1` row
with **no `memory_type` filter**:

```sql
DELETE FROM llm_bot_memories
 WHERE bot_guid = %s AND player_guid = %s AND active = 1 AND used = 1
 ORDER BY RAND() LIMIT 1
```

Both callers route through it (the insert-time cap check in
`_ensure_cap_and_insert`, and the group-activation prune loop). A `first_meeting`
row acquires `used=1` the first time a returning player is greeted: the reunion
recall path calls `get_bot_memories()`, which defaults to
`exclude_first_meeting=False`, and every returned row is stamped `used=1`. So a
`first_meeting` memory becomes eviction-eligible as soon as it is recalled once.

Once it is evicted, the insert-time dedup guard (`WHERE NOT EXISTS (…
memory_type='first_meeting')`) passes again, and the next encounter writes a
**fresh** `first_meeting` with the current date and zone. A bot that has
adventured with a player for months would then greet them as a stranger and
record having just met them — and `first_meeting` is the one memory type written
as a templated fact rather than LLM prose, precisely because it must never be
wrong.

The protection that does exist is narrower and covers different things:
insert-time dedup, and exclusion from *idle* recall (`exclude_first_meeting=True`
in the idle paths). Neither prevents eviction.

## Fix

Add `AND memory_type != 'first_meeting'` to the eviction `DELETE`, so
`first_meeting` is never evicted. When only `first_meeting` rows remain, the
function deletes nothing and returns `False` (fail closed) — a result both
callers already handle (return "pool full" / break). Selection among the
remaining evictable rows is unchanged. Code now matches the documented
behaviour.

## Testing

- `python -m py_compile` on the changed file.
- Simulated the eviction loop over a pool of one `first_meeting` row plus several
  `used=1` non-first_meeting rows: all non-first_meeting rows are evicted, the
  `first_meeting` row survives, and the loop then returns `False` (fails closed)
  rather than deleting the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
